### PR TITLE
feat: online time controls (Fischer clocks)

### DIFF
--- a/.claude/hooks/format.sh
+++ b/.claude/hooks/format.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-FILE_PATH=$(jq -r '.tool_input.file_path' < /dev/stdin)
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 
 [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ] && exit 0
 

--- a/.claude/hooks/format.sh
+++ b/.claude/hooks/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 

--- a/.claude/hooks/format.sh
+++ b/.claude/hooks/format.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+FILE_PATH=$(jq -r '.tool_input.file_path' < /dev/stdin)
+
+[ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ] && exit 0
+
+if [[ "$FILE_PATH" == *.hs ]]; then
+  fourmolu -i "$FILE_PATH" 2>/dev/null
+elif [[ "$FILE_PATH" == *.ts ]] || [[ "$FILE_PATH" == *.tsx ]]; then
+  npx biome format --write "$FILE_PATH" 2>/dev/null
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,16 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/format.sh"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/format.sh"
           }
         ]
       }

--- a/.claude/skills/commit-change/SKILL.md
+++ b/.claude/skills/commit-change/SKILL.md
@@ -53,38 +53,35 @@ all tests must pass — not just the new ones.
 
 ## Commit message format
 
-Follow conventional commit format. Structure the message as:
+Follow conventional commit format with labeled sections for
+scannability. Every section after the summary line uses a
+`Section:` label prefix.
 
 ```
-<type>(<scope>): <summary>
+<type>(<scope>): <summary line, under 72 chars>
 
-<contextualization paragraph>
+Context: <what this builds on and what it enables — omit for
+standalone changes>
 
-<acceptance criteria paragraph>
+Changes: <what was done, as a bulleted list>
+
+Tests: <specific tests added and what they cover — or why manual
+verification was used instead>
 ```
 
-### Summary line
+### Rules
 
-Concise description of what changed. Under 72 characters.
-
-### Contextualization paragraph
-
-- If this extends work from a recent commit, **name it** (e.g.,
-  "Builds on the TimeControl storage layer added in the previous
-  commit").
-- State what this enables — the immediate technical next step and/or
-  the broader feature goal (e.g., "This completes the backend data
-  path, enabling the frontend to send time controls in the next
-  step").
-- Omit this paragraph for standalone changes with no surrounding
-  context.
-
-### Acceptance criteria paragraph
-
-- Name the specific tests added (e.g., "Tested by new round-trip
-  tests in OnlineTest.hs covering timed and untimed creation").
-- If manual verification was used, explain **why tests were not
-  feasible** and what was verified.
+- **Summary line**: one sentence, under 72 characters. Present tense.
+- **Context**: only include if this commit extends prior work or
+  enables a specific next step. Name the prior commit or feature
+  goal. Omit entirely for standalone changes.
+- **Changes**: bulleted list of what changed. One bullet per
+  concern/file-group. Terse — a reviewer reading `git log` should
+  parse this in seconds.
+- **Tests**: name the test file(s) and what they exercise. If manual
+  verification was used, explain why tests were infeasible.
+- Keep lines under 72 characters for `git log` readability.
+- No filler, no restating the summary in the body.
 
 ## Process
 
@@ -99,7 +96,13 @@ Concise description of what changed. Under 72 characters.
    git commit -m "$(cat <<'EOF'
    <type>(<scope>): <summary>
 
-   <body>
+   Context: ...
+
+   Changes:
+   - ...
+   - ...
+
+   Tests: ...
 
    Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
    EOF

--- a/.claude/skills/commit-change/SKILL.md
+++ b/.claude/skills/commit-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit-change
 description: Create an atomic commit with verified acceptance criteria and a well-structured message. Invoke when ready to commit a change.
-allowed-tools: Read Glob Grep Bash(git:*) Edit
+allowed-tools: Read Glob Grep Bash(git *) Edit
 ---
 
 # Commit an Atomic Change

--- a/.claude/skills/commit-change/SKILL.md
+++ b/.claude/skills/commit-change/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: commit-change
+description: Create an atomic commit with verified acceptance criteria and a well-structured message. Invoke when ready to commit a change.
+allowed-tools: Read Glob Grep Bash(git:*) Edit
+---
+
+# Commit an Atomic Change
+
+You are creating a commit. Actively verify that the change meets all
+requirements below — run the commands, read the output, do not
+self-report.
+
+## Pre-commit checklist
+
+### 1. Scope check
+
+- [ ] The change contains only what is in scope for this commit.
+- [ ] No unrelated cleanups, fixes, or "while I'm here" additions
+      have crept in.
+- [ ] The change represents one coherent idea.
+- [ ] A reviewer can understand the diff in isolation.
+
+### 2. Acceptance criteria are met
+
+- [ ] New or updated tests exercise the change.
+- [ ] Tests cover **every substantive part** of the change — not just
+      the easiest path. If the commit touches N files/concerns, the
+      tests must exercise all N, not a subset.
+- [ ] All new verification is part of the project's test suite, not
+      ad-hoc commands.
+- [ ] If manual verification was used instead of tests: confirm it is
+      because tests are **technically infeasible**, not merely
+      inconvenient.
+
+### 3. Size check
+
+Run `git diff --cached --stat` after staging and check the output:
+
+- [ ] ≤200 lines of substantive, novel code: good.
+- [ ] 200–400 lines: acceptable but note it in the commit message.
+- [ ] >400 lines of non-mechanical code: do not commit. Split first.
+
+### 4. Codebase is green
+
+Run the full test suite for every subproject touched by this commit:
+
+- C library: `cd libhnefatafl && make test`
+- Backend: `cd backend && cabal test`
+- Frontend: `cd frontend && npm run check:all`
+
+Read the output. Do not assume success. The codebase must compile and
+all tests must pass — not just the new ones.
+
+## Commit message format
+
+Follow conventional commit format. Structure the message as:
+
+```
+<type>(<scope>): <summary>
+
+<contextualization paragraph>
+
+<acceptance criteria paragraph>
+```
+
+### Summary line
+
+Concise description of what changed. Under 72 characters.
+
+### Contextualization paragraph
+
+- If this extends work from a recent commit, **name it** (e.g.,
+  "Builds on the TimeControl storage layer added in the previous
+  commit").
+- State what this enables — the immediate technical next step and/or
+  the broader feature goal (e.g., "This completes the backend data
+  path, enabling the frontend to send time controls in the next
+  step").
+- Omit this paragraph for standalone changes with no surrounding
+  context.
+
+### Acceptance criteria paragraph
+
+- Name the specific tests added (e.g., "Tested by new round-trip
+  tests in OnlineTest.hs covering timed and untimed creation").
+- If manual verification was used, explain **why tests were not
+  feasible** and what was verified.
+
+## Process
+
+1. Stage the relevant files (`git add <specific files>`). Never use
+   `git add -A` or `git add .`.
+2. Run `git diff --cached --stat` and check the size.
+3. Run the full test suite (step 4 of the checklist). Read the output.
+4. If any check fails, fix the issue before proceeding.
+5. Write the commit message following the format above.
+6. Create the commit. Use a HEREDOC for the message:
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   <type>(<scope>): <summary>
+
+   <body>
+
+   Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+7. Verify the commit succeeded (`git log -1`). If a pre-commit hook
+   fails, fix the issue and create a **new** commit — do not amend.

--- a/.claude/skills/commit-change/SKILL.md
+++ b/.claude/skills/commit-change/SKILL.md
@@ -95,7 +95,9 @@ verification was used instead>
 3. Run the full test suite (step 4 of the checklist). Read the output.
 4. If any check fails, fix the issue before proceeding.
 5. Write the commit message following the format above.
-6. Create the commit. Use a HEREDOC for the message:
+6. **Present the commit message to the user for review before
+   committing.** Do not run `git commit` until the user approves.
+7. Create the commit. Use a HEREDOC for the message:
    ```bash
    git commit -m "$(cat <<'EOF'
    <type>(<scope>): <summary>

--- a/.claude/skills/commit-change/SKILL.md
+++ b/.claude/skills/commit-change/SKILL.md
@@ -73,8 +73,12 @@ verification was used instead>
 
 - **Summary line**: one sentence, under 72 characters. Present tense.
 - **Context**: only include if this commit extends prior work or
-  enables a specific next step. Name the prior commit or feature
-  goal. Omit entirely for standalone changes.
+  enables a specific next step. Must be self-contained — a reader
+  seeing only `git log` must understand it without access to any
+  plan document, ticket, or conversation. Never reference plan
+  slice numbers, step IDs, or internal jargon. Describe what
+  this builds on and enables in plain terms. Omit entirely for
+  standalone changes.
 - **Changes**: bulleted list of what changed. One bullet per
   concern/file-group. Terse — a reviewer reading `git log` should
   parse this in seconds.

--- a/.claude/skills/plan-commits/SKILL.md
+++ b/.claude/skills/plan-commits/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: plan-commits
+description: Break a task into atomic, commit-sized steps with acceptance criteria. Invoke before starting ANY implementation work.
+allowed-tools: Read Glob Grep Bash(git:*) Agent
+---
+
+# Plan Atomic Commits
+
+You are planning implementation work. Break the task into a sequence of
+atomic commits, each coherent and comprehensible as a single unit.
+
+This skill is invoked for ALL implementation work — even tasks that
+look like a single commit. Scope is not always obvious upfront, and
+the planning step ensures you think through what changes, what to
+test, and how to verify before writing code.
+
+## Commit size limits
+
+- **Target**: ≤200 lines of substantive, novel code changes per commit.
+- **Hard limit**: 400 lines. Never exceed this for non-trivial code.
+- **Exempt**: purely mechanical/repetitive changes (renames, reformats,
+  migrations that follow a pattern) and lockfiles may exceed these limits.
+
+## Atomicity
+
+Each commit represents one coherent idea: adding a set of DB queries,
+implementing a module of pure logic, wiring up an endpoint, etc. A
+reviewer should be able to understand the commit in isolation without
+needing context from uncommitted future work.
+
+Incremental building blocks are fine — a commit can add code that is
+unused until the following commit. The unit of coherence is the idea,
+not "is it called yet."
+
+## Scope discipline
+
+A commit contains only what is in its scope. If during implementation
+you notice something unrelated that should change — a nearby cleanup,
+an unrelated bug, a "while I'm here" improvement — do not include it.
+Note it for a separate commit.
+
+## Codebase must stay green
+
+Every commit must leave the codebase in a state where it compiles and
+the full test suite passes. No "this commit breaks the build but the
+next one fixes it."
+
+## Required fields per commit
+
+Every commit in the plan must include all of these:
+
+- **Scope**: the coherent idea this commit represents, in one sentence.
+- **Changes**: specific files and what changes in each. Read the
+  codebase to identify the right files and understand existing patterns
+  before specifying changes.
+- **Builds on**: which prior commit(s) this extends, and what concrete
+  outputs it uses (e.g., "uses `SetClockState` command from 2.1").
+  Omit for standalone changes or the first commit in a sequence.
+- **Enables**: what this unlocks — a) the immediate technical next
+  step that will build on this, and b) progress toward the overall
+  feature goal.
+- **Acceptance criteria**: the specific tests to be written. Name what
+  they cover and which parts of the change they exercise. Tests are
+  **required** unless technically infeasible — not merely inconvenient.
+  **Coverage must account for every substantive part of the change** —
+  if a commit touches three files, the tests must exercise all three,
+  not just the easiest one to test. All new automatable verification
+  must be part of the project's test suite, not ad-hoc commands.
+- **Est. size**: line count estimate.
+
+## Plan structure
+
+For multi-commit work, use this document structure:
+
+```markdown
+# [Feature] — Implementation Plan
+
+## Context
+[What we're building and why, in a few sentences.]
+
+## Progress
+| # | Commit | Status |
+|---|--------|--------|
+| 1 | `feat(scope): summary` | not started |
+| ... | ... | ... |
+
+---
+
+### 1 — `feat(scope): summary`
+
+**Scope:** ...
+**Builds on:** ...
+**Enables:** ...
+
+**Changes:**
+- `path/to/file.hs` — description of change
+- ...
+
+**Acceptance criteria:**
+- Tests: ...
+
+**Est. size:** ~N lines.
+```
+
+For single-commit work, the same fields apply but no document is
+needed — present them inline in the conversation.
+
+Update the Progress table as commits are completed.
+
+## Process
+
+1. **Read the codebase first.** Understand existing patterns, types, and
+   file structure before proposing changes. Never guess at file paths
+   or function signatures.
+2. **Estimate sizes.** If a commit looks like it will exceed 200 lines,
+   consider splitting. If it would exceed 400 lines, it must be split.
+3. **Verify coherence.** Each commit should be understandable in
+   isolation. Ask: "Could a reviewer make sense of this diff without
+   knowing what comes next?"
+4. **Present the plan for review** before starting implementation.

--- a/.claude/skills/plan-commits/SKILL.md
+++ b/.claude/skills/plan-commits/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-commits
 description: Break a task into atomic, commit-sized steps with acceptance criteria. Invoke before starting ANY implementation work.
-allowed-tools: Read Glob Grep Bash(git:*) Agent
+allowed-tools: Read Glob Grep Bash(git *) Agent
 ---
 
 # Plan Atomic Commits

--- a/.claude/skills/review-best-practices/SKILL.md
+++ b/.claude/skills/review-best-practices/SKILL.md
@@ -3,7 +3,7 @@ name: review-best-practices
 description: Review code for language-specific best practices and idiomatic patterns, especially Haskell FP
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git *)
+allowed-tools: Read Glob Grep Bash(git *) Read(//tmp/**) Write(//tmp/**)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-best-practices/SKILL.md
+++ b/.claude/skills/review-best-practices/SKILL.md
@@ -3,7 +3,7 @@ name: review-best-practices
 description: Review code for language-specific best practices and idiomatic patterns, especially Haskell FP
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git:*)
+allowed-tools: Read Glob Grep Bash(git *)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-best-practices/SKILL.md
+++ b/.claude/skills/review-best-practices/SKILL.md
@@ -25,7 +25,21 @@ Apply your full knowledge of language-specific best practices — don't limit yo
 
 ### Haskell (primary focus)
 
-The core principle: **model logic in pure functions and push effects to the edge.** Business rules, validation, and data transformation should be pure. Effectful code (IO, database, network) should be thin shells that orchestrate pure logic.
+Core principles:
+
+- **Parse, don't validate.** Push validation to boundaries so
+  internal code only handles well-typed values.
+- **Make invalid states unrepresentable.** Use newtypes with hidden
+  constructors + smart constructors, sum types over booleans,
+  refined predicates where appropriate. Scrutinize whether sloppy
+  or overly permissive data modeling: (a) allows constructing
+  invalid data, (b) risks bugs by not imposing invariants that
+  future changes could violate, (c) forces handling "impossible"
+  cases, or (d) obscures intent.
+- **Model logic in pure functions, push effects to the edge.**
+  Business rules, validation, and data transformation should be
+  pure. Effectful code should be thin shells that orchestrate pure
+  logic.
 
 This project uses Effectful for its effect system and optics for record access. Check that usage is consistent with the rest of the codebase.
 

--- a/.claude/skills/review-best-practices/SKILL.md
+++ b/.claude/skills/review-best-practices/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: review-best-practices
+description: Review code for language-specific best practices and idiomatic patterns, especially Haskell FP
+context: fork
+agent: Explore
+allowed-tools: Read Glob Grep Bash(git:*)
+arguments:
+  - name: target
+    description: Diff text or file paths to review
+---
+
+# Language Best Practices Review
+
+You are reviewing code for idiomatic use of each language and adherence to best practices. Analyze the provided changes or files and report findings.
+
+## Target
+
+$ARGUMENTS
+
+## Approach
+
+Assess whether the code uses its language idiomatically and follows established best practices for that ecosystem. The goal is code that an expert in that language would recognize as well-written — not just correct, but natural.
+
+Apply your full knowledge of language-specific best practices — don't limit yourself to what's listed here. The notes below highlight key principles for this project but are starting points, not boundaries.
+
+### Haskell (primary focus)
+
+The core principle: **model logic in pure functions and push effects to the edge.** Business rules, validation, and data transformation should be pure. Effectful code (IO, database, network) should be thin shells that orchestrate pure logic.
+
+This project uses Effectful for its effect system and optics for record access. Check that usage is consistent with the rest of the codebase.
+
+### C
+
+This is a bitboard-based game engine. Consider idioms appropriate to low-level, performance-sensitive C.
+
+### TypeScript / SolidJS
+
+This is a reactive UI. Consider idioms appropriate to SolidJS's fine-grained reactivity model.
+
+## How to investigate
+
+1. Read the changed files to understand the language and framework context
+2. Check how similar patterns are handled elsewhere in the codebase
+3. Read the relevant CLAUDE.md for project-specific patterns
+4. Identify anti-patterns specific to the language/framework in use
+
+## Output format
+
+Return your findings using this structure exactly:
+
+## Language Best Practices Review
+
+### Critical
+- **file:line** — description — suggested fix
+
+### Major
+- **file:line** — description — suggested fix
+
+### Minor
+- **file:line** — description — suggested fix
+
+### Positive
+- Notable best practice adherence observed
+
+If a severity level has no findings, omit that section. Always include at least a Positive section.

--- a/.claude/skills/review-composability/SKILL.md
+++ b/.claude/skills/review-composability/SKILL.md
@@ -3,7 +3,7 @@ name: review-composability
 description: Review code for modularity, interface design, coupling, and reuse potential
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git *)
+allowed-tools: Read Glob Grep Bash(git *) Read(//tmp/**) Write(//tmp/**)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-composability/SKILL.md
+++ b/.claude/skills/review-composability/SKILL.md
@@ -3,7 +3,7 @@ name: review-composability
 description: Review code for modularity, interface design, coupling, and reuse potential
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git:*)
+allowed-tools: Read Glob Grep Bash(git *)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-composability/SKILL.md
+++ b/.claude/skills/review-composability/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: review-composability
+description: Review code for modularity, interface design, coupling, and reuse potential
+context: fork
+agent: Explore
+allowed-tools: Read Glob Grep Bash(git:*)
+arguments:
+  - name: target
+    description: Diff text or file paths to review
+---
+
+# Composability Review
+
+You are reviewing code for modularity, composability, and clean architecture. Analyze the provided changes or files and report findings.
+
+## Target
+
+$ARGUMENTS
+
+## Approach
+
+Assess whether the code is composed of well-separated, reusable parts with clean interfaces. Think about how this code would behave if requirements changed — would you need to rewrite it, or could you recombine its pieces?
+
+Key questions to drive your analysis:
+- Does each module/function have a single, clear responsibility?
+- Are interfaces narrow — do functions take only what they need and return only what callers need?
+- Are internal details properly encapsulated, or do consumers reach into implementation?
+- Does the change increase or decrease coupling between modules or sub-projects?
+- Could these pieces be reused in a different context without modification?
+- Is shared state minimized and made explicit?
+
+Adapt your focus to the language:
+- **Haskell**: effect constraints should be minimal, types composed from smaller pieces, functions generalizable over typeclasses where natural
+- **C**: static linkage for internal functions, clean header interfaces, separation of data structures from algorithms
+- **TypeScript/SolidJS**: component boundaries, prop interfaces, separation of logic from presentation
+
+## How to investigate
+
+1. Read the changed files and their module headers/exports
+2. Check what imports/depends on the modified code (grep for usages)
+3. Look at the module structure around the change
+4. Consider whether the change makes future extension easier or harder
+
+## Output format
+
+Return your findings using this structure exactly:
+
+## Composability Review
+
+### Critical
+- **file:line** — description — suggested fix
+
+### Major
+- **file:line** — description — suggested fix
+
+### Minor
+- **file:line** — description — suggested fix
+
+### Positive
+- Notable composability strengths observed
+
+If a severity level has no findings, omit that section. Always include at least a Positive section.

--- a/.claude/skills/review-composability/SKILL.md
+++ b/.claude/skills/review-composability/SKILL.md
@@ -19,14 +19,27 @@ $ARGUMENTS
 
 ## Approach
 
-Assess whether the code is composed of well-separated, reusable parts with clean interfaces. Think about how this code would behave if requirements changed — would you need to rewrite it, or could you recombine its pieces?
+Good composability means building solutions from small, principled,
+atomic pieces of functionality. When code is written this way, reuse
+falls out naturally — different solutions share the same building
+blocks. The goal is NOT "find similar code and merge it." It is:
+are the abstractions at the right level? Is each piece doing one
+thing well? Could these pieces be recombined to solve a different
+problem?
 
 Key questions to drive your analysis:
-- Does each module/function have a single, clear responsibility?
-- Are interfaces narrow — do functions take only what they need and return only what callers need?
-- Are internal details properly encapsulated, or do consumers reach into implementation?
-- Does the change increase or decrease coupling between modules or sub-projects?
-- Could these pieces be reused in a different context without modification?
+- Is each function a well-defined, atomic unit of work — or is it
+  a monolith doing several things that should be separate?
+- Are abstractions at the right level — reusable primitives vs
+  one-off combinations?
+- Could this logic be expressed as a composition of existing,
+  smaller pieces?
+- Are concerns properly separated so pieces can be recombined
+  for different purposes?
+- Are interfaces narrow — do functions take only what they need
+  and return only what callers need?
+- Are internal details properly encapsulated, or do consumers
+  reach into implementation?
 - Is shared state minimized and made explicit?
 
 Adapt your focus to the language:

--- a/.claude/skills/review-correctness/SKILL.md
+++ b/.claude/skills/review-correctness/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: review-correctness
+description: Review code for logic errors, edge cases, and invariant violations
+context: fork
+agent: Explore
+allowed-tools: Read Glob Grep Bash(git:*)
+arguments:
+  - name: target
+    description: Diff text or file paths to review
+---
+
+# Correctness Review
+
+You are reviewing code for logical correctness. Analyze the provided changes or files and report findings.
+
+## Target
+
+$ARGUMENTS
+
+## What to look for
+
+- Logic errors, off-by-one mistakes, incorrect conditions
+- Unhandled edge cases and boundary conditions
+- Invariant violations — preconditions assumed but not enforced
+- Undefined behavior (C): signed overflow, null dereference, out-of-bounds access
+- Pattern match exhaustiveness and missing cases (Haskell)
+- Null/undefined handling and type narrowing gaps (TypeScript)
+- State machine transitions that skip or duplicate steps
+- Resource lifecycle — opened but not closed, allocated but not freed
+- Race conditions or ordering assumptions in concurrent code
+
+## How to investigate
+
+1. Read the changed files to understand the full context around each change
+2. Trace data flow through the affected functions
+3. Check callers and callees of modified functions for contract mismatches
+4. Look for related test files to see if edge cases are covered
+
+## Output format
+
+Return your findings using this structure exactly:
+
+## Correctness Review
+
+### Critical
+- **file:line** — description — suggested fix
+
+### Major
+- **file:line** — description — suggested fix
+
+### Minor
+- **file:line** — description — suggested fix
+
+### Positive
+- Notable correctness strengths observed
+
+If a severity level has no findings, omit that section. Always include at least a Positive section noting what was done well.

--- a/.claude/skills/review-correctness/SKILL.md
+++ b/.claude/skills/review-correctness/SKILL.md
@@ -3,7 +3,7 @@ name: review-correctness
 description: Review code for logic errors, edge cases, and invariant violations
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git *)
+allowed-tools: Read Glob Grep Bash(git *) Read(//tmp/**) Write(//tmp/**)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-correctness/SKILL.md
+++ b/.claude/skills/review-correctness/SKILL.md
@@ -3,7 +3,7 @@ name: review-correctness
 description: Review code for logic errors, edge cases, and invariant violations
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git:*)
+allowed-tools: Read Glob Grep Bash(git *)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-documentation/SKILL.md
+++ b/.claude/skills/review-documentation/SKILL.md
@@ -19,6 +19,12 @@ $ARGUMENTS
 
 ## What to look for
 
+Evaluate the code **as it stands now**. The question is always
+"does this code have the documentation it needs?" — not "what
+changed." A missing comment is a finding whether it was never
+there or was removed during this change. Frame findings in terms
+of what the code is, not what it was.
+
 - Code whose purpose is not immediately evident from usage
   should be documented. Emphasize the **why**, not the **what**.
 - Only document **how** the code works if the implementation is
@@ -26,6 +32,12 @@ $ARGUMENTS
   that way.
 - Undocumented non-obvious code is a finding.
 - Redundant comments on self-evident code are also a finding.
+- **Documentation describes what a unit of code IS** — its
+  contract, behavior, preconditions, invariants — never how it
+  is called or what calls it. Each unit must be comprehensible
+  from its signature, documentation, and implementation alone.
+  Comments that reference callers or external context invert
+  the flow of comprehension and are a finding.
 
 ## How to investigate
 

--- a/.claude/skills/review-documentation/SKILL.md
+++ b/.claude/skills/review-documentation/SKILL.md
@@ -3,7 +3,7 @@ name: review-documentation
 description: Review code for appropriate documentation — present where needed, absent where redundant
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git *)
+allowed-tools: Read Glob Grep Bash(git *) Read(//tmp/**) Write(//tmp/**)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-documentation/SKILL.md
+++ b/.claude/skills/review-documentation/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: review-documentation
+description: Review code for appropriate documentation — present where needed, absent where redundant
+context: fork
+agent: Explore
+allowed-tools: Read Glob Grep Bash(git *)
+arguments:
+  - name: target
+    description: Diff text or file paths to review
+---
+
+# Documentation Review
+
+You are reviewing code for appropriate documentation. Analyze the provided changes or files and report findings.
+
+## Target
+
+$ARGUMENTS
+
+## What to look for
+
+- Code whose purpose is not immediately evident from usage
+  should be documented. Emphasize the **why**, not the **what**.
+- Only document **how** the code works if the implementation is
+  surprising or non-obvious — and then also explain why it works
+  that way.
+- Undocumented non-obvious code is a finding.
+- Redundant comments on self-evident code are also a finding.
+
+## How to investigate
+
+1. Read the changed files and consider: would a competent
+   developer new to this codebase understand this code without
+   the comment? If yes, the comment is noise. If no, a comment
+   is missing.
+2. Check existing documentation style in the codebase for
+   consistency.
+3. Look for magic numbers, non-obvious algorithms, subtle
+   invariants, or surprising design choices that lack explanation.
+
+## Output format
+
+Return your findings using this structure exactly:
+
+## Documentation Review
+
+### Critical
+- **file:line** — description — suggested fix
+
+### Major
+- **file:line** — description — suggested fix
+
+### Minor
+- **file:line** — description — suggested fix
+
+### Positive
+- Notable documentation strengths observed
+
+If a severity level has no findings, omit that section. Always include at least a Positive section.

--- a/.claude/skills/review-performance/SKILL.md
+++ b/.claude/skills/review-performance/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: review-performance
+description: Review code for performance issues, algorithmic complexity, and resource efficiency
+context: fork
+agent: Explore
+allowed-tools: Read Glob Grep Bash(git:*)
+arguments:
+  - name: target
+    description: Diff text or file paths to review
+---
+
+# Performance Review
+
+You are reviewing code for performance issues and efficiency. Analyze the provided changes or files and report findings.
+
+## Target
+
+$ARGUMENTS
+
+## Approach
+
+Think holistically about performance. Don't limit yourself to a fixed checklist — consider any way this code could be slower, use more memory, or scale worse than it needs to given its context.
+
+Key questions to drive your analysis:
+- What are the hot paths here, and how does this code behave as input scales?
+- Are there redundant computations, unnecessary allocations, or wasted I/O?
+- Does the choice of data structure match the actual access pattern?
+- Are there latent scaling problems that will only appear under load or with larger data?
+
+Adapt your focus to the language and runtime:
+- **C**: think about cache locality, allocation patterns, and algorithmic complexity in the engine's tight loops
+- **Haskell**: think about laziness, strictness, space leaks, fusion, and database query patterns
+- **TypeScript/SolidJS**: think about reactive granularity, bundle size, and render efficiency
+
+## How to investigate
+
+1. Read the changed files to understand the performance context
+2. Identify hot paths — code called frequently or in tight loops
+3. Check if existing benchmarks or performance tests cover the area
+4. Look at data structure choices relative to access patterns
+
+## Output format
+
+Return your findings using this structure exactly:
+
+## Performance Review
+
+### Critical
+- **file:line** — description — suggested fix
+
+### Major
+- **file:line** — description — suggested fix
+
+### Minor
+- **file:line** — description — suggested fix
+
+### Positive
+- Notable performance strengths observed
+
+If a severity level has no findings, omit that section. Always include at least a Positive section.

--- a/.claude/skills/review-performance/SKILL.md
+++ b/.claude/skills/review-performance/SKILL.md
@@ -3,7 +3,7 @@ name: review-performance
 description: Review code for performance issues, algorithmic complexity, and resource efficiency
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git:*)
+allowed-tools: Read Glob Grep Bash(git *)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-performance/SKILL.md
+++ b/.claude/skills/review-performance/SKILL.md
@@ -3,7 +3,7 @@ name: review-performance
 description: Review code for performance issues, algorithmic complexity, and resource efficiency
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git *)
+allowed-tools: Read Glob Grep Bash(git *) Read(//tmp/**) Write(//tmp/**)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-security/SKILL.md
+++ b/.claude/skills/review-security/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: review-security
+description: Review code for security vulnerabilities and safety issues
+context: fork
+agent: Explore
+allowed-tools: Read Glob Grep Bash(git:*)
+arguments:
+  - name: target
+    description: Diff text or file paths to review
+---
+
+# Security Review
+
+You are reviewing code for security vulnerabilities and safety issues. Analyze the provided changes or files and report findings.
+
+## Target
+
+$ARGUMENTS
+
+## Approach
+
+Think broadly about security. Don't limit yourself to a fixed checklist — consider any way the code could be exploited, misused, or fail unsafely given its context. Consider the OWASP top 10, CWE categories, and language-specific vulnerability classes, but treat those as starting points, not boundaries.
+
+Key questions to drive your analysis:
+- Where does untrusted input enter and how far does it travel before validation?
+- What trust boundaries does this code sit on or cross?
+- What happens if any assumption this code makes turns out to be false?
+- What can an attacker control, and what can they reach from there?
+- Are there failure modes that degrade security rather than denying access?
+
+Adapt your focus to the language:
+- **C**: memory safety is paramount — but also consider logic-level vulnerabilities
+- **Haskell**: type safety handles many classes of bugs, so focus on boundaries — FFI, IO, serialization, network-facing code, auth logic
+- **TypeScript**: client-side code is attacker-controlled — focus on what it trusts and what the server validates
+
+## How to investigate
+
+1. Read the changed files and understand the security context
+2. Identify trust boundaries the code touches
+3. Trace data from untrusted sources through to sensitive operations
+4. Check that the code fails closed rather than open
+5. Look for related security tests or validation logic
+
+## Output format
+
+Return your findings using this structure exactly:
+
+## Security Review
+
+### Critical
+- **file:line** — description — suggested fix
+
+### Major
+- **file:line** — description — suggested fix
+
+### Minor
+- **file:line** — description — suggested fix
+
+### Positive
+- Notable security strengths observed
+
+If a severity level has no findings, omit that section. Always include at least a Positive section.

--- a/.claude/skills/review-security/SKILL.md
+++ b/.claude/skills/review-security/SKILL.md
@@ -3,7 +3,7 @@ name: review-security
 description: Review code for security vulnerabilities and safety issues
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git *)
+allowed-tools: Read Glob Grep Bash(git *) Read(//tmp/**) Write(//tmp/**)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-security/SKILL.md
+++ b/.claude/skills/review-security/SKILL.md
@@ -3,7 +3,7 @@ name: review-security
 description: Review code for security vulnerabilities and safety issues
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git:*)
+allowed-tools: Read Glob Grep Bash(git *)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-style/SKILL.md
+++ b/.claude/skills/review-style/SKILL.md
@@ -3,7 +3,7 @@ name: review-style
 description: Review code for readability, naming, duplication, and adherence to project conventions
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git *)
+allowed-tools: Read Glob Grep Bash(git *) Read(//tmp/**) Write(//tmp/**)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-style/SKILL.md
+++ b/.claude/skills/review-style/SKILL.md
@@ -3,7 +3,7 @@ name: review-style
 description: Review code for readability, naming, duplication, and adherence to project conventions
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git:*)
+allowed-tools: Read Glob Grep Bash(git *)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-style/SKILL.md
+++ b/.claude/skills/review-style/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: review-style
+description: Review code for readability, naming, duplication, and adherence to project conventions
+context: fork
+agent: Explore
+allowed-tools: Read Glob Grep Bash(git:*)
+arguments:
+  - name: target
+    description: Diff text or file paths to review
+---
+
+# Style & Maintainability Review
+
+You are reviewing code for readability, conventions, and maintainability. Analyze the provided changes or files and report findings.
+
+## Target
+
+$ARGUMENTS
+
+## Approach
+
+Assess whether the code is clear, consistent, and easy to work with. Think about the person who reads this code next — will they understand it quickly? Will they be able to modify it confidently?
+
+Key questions to drive your analysis:
+- Would someone unfamiliar with this code understand what it does and why?
+- Does the new code match the style and patterns of the code around it?
+- Is there duplication that obscures the underlying structure?
+- Are names precise — do they say what they mean without being verbose?
+- Is anything dead, vestigial, or unnecessarily complex?
+
+## Project conventions
+
+Before reviewing, read the relevant CLAUDE.md file(s) to understand project-specific conventions:
+- `/home/ftzm/dev/hnefatafl/CLAUDE.md` (root — especially comment style rules)
+- `/home/ftzm/dev/hnefatafl/libhnefatafl/CLAUDE.md`
+- `/home/ftzm/dev/hnefatafl/backend/CLAUDE.md`
+- `/home/ftzm/dev/hnefatafl/frontend/CLAUDE.md`
+
+These contain binding conventions (comment style, naming, CSS units, etc.) — check the code against them.
+
+## How to investigate
+
+1. Read the changed files in full to understand surrounding style
+2. Check CLAUDE.md files for project-specific conventions
+3. Compare with adjacent code in the same module for consistency
+4. Look for patterns in the broader codebase when unsure about conventions
+
+## Output format
+
+Return your findings using this structure exactly:
+
+## Style & Maintainability Review
+
+### Critical
+- **file:line** — description — suggested fix
+
+### Major
+- **file:line** — description — suggested fix
+
+### Minor
+- **file:line** — description — suggested fix
+
+### Positive
+- Notable style strengths observed
+
+If a severity level has no findings, omit that section. Always include at least a Positive section.

--- a/.claude/skills/review-testing/SKILL.md
+++ b/.claude/skills/review-testing/SKILL.md
@@ -3,7 +3,7 @@ name: review-testing
 description: Review code for thorough, well-structured test coverage
 context: fork
 agent: Explore
-allowed-tools: Read Glob Grep Bash(git *)
+allowed-tools: Read Glob Grep Bash(git *) Read(//tmp/**) Write(//tmp/**)
 arguments:
   - name: target
     description: Diff text or file paths to review

--- a/.claude/skills/review-testing/SKILL.md
+++ b/.claude/skills/review-testing/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: review-testing
+description: Review code for thorough, well-structured test coverage
+context: fork
+agent: Explore
+allowed-tools: Read Glob Grep Bash(git *)
+arguments:
+  - name: target
+    description: Diff text or file paths to review
+---
+
+# Testing Review
+
+You are reviewing code for thorough, well-structured test coverage. Analyze the provided changes or files and report findings.
+
+## Target
+
+$ARGUMENTS
+
+## What to look for
+
+### Coverage
+- All non-tautological code should be tested. Simple line
+  coverage is not enough.
+- For any non-trivial logic, ask: how could this break? Under
+  what usage patterns could it break? Are those scenarios
+  exercised in tests?
+- Edge cases, boundary conditions, error paths, and state
+  transitions should all have test cases.
+- For concurrent or event-driven code: what happens if events
+  arrive out of order? If one operation fires before another
+  completes? If two operations race? These timing scenarios
+  need tests.
+- Untested code paths are findings, proportional to their risk.
+
+### Test quality
+- Test cases should be simple and focused on what is being
+  tested, not on setup ceremony.
+- When test setup becomes cumbersome, look for opportunities to
+  extract principled, generic test helpers. Helpers should reduce
+  accidental complexity without hiding what the test verifies.
+- Tests should be readable as specifications: a reader should
+  understand the expected behavior from the test alone.
+- Avoid testing implementation details — test behavior and
+  contracts.
+
+## How to investigate
+
+1. Read the changed code and identify all branches, edge cases,
+   and error conditions.
+2. Find the corresponding test files and check which scenarios
+   are covered.
+3. Look at existing test helpers and patterns in the codebase —
+   could they be reused or extended?
+4. Check if new test helpers would reduce duplication across
+   test cases.
+
+## Output format
+
+Return your findings using this structure exactly:
+
+## Testing Review
+
+### Critical
+- **file:line** — description — suggested fix
+
+### Major
+- **file:line** — description — suggested fix
+
+### Minor
+- **file:line** — description — suggested fix
+
+### Positive
+- Notable testing strengths observed
+
+If a severity level has no findings, omit that section. Always include at least a Positive section.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review
 description: Run a multi-dimensional code review using parallel sub-agents
-allowed-tools: Read Glob Grep Bash(git *) Agent Skill
+allowed-tools: Read Glob Grep Bash(git *) Agent
 arguments:
   - name: target
     description: What to review — file paths, a git ref like HEAD~3, a branch name, etc.
@@ -26,18 +26,24 @@ Capture the diff or file contents — you'll pass this to each sub-reviewer.
 
 ## Step 2: Dispatch sub-reviewers
 
-Spawn **all 8** of these sub-reviewer skills in parallel using the Skill tool, passing the diff/file content as the argument to each:
+Spawn **all 8** sub-reviewers **in parallel using the Agent tool** — all 8 Agent calls in a **single message**. This is critical for parallelism; the Agent tool runs concurrently when multiple calls are in one message.
 
-1. `/review-correctness`
-2. `/review-security`
-3. `/review-performance`
-4. `/review-style`
-5. `/review-composability`
-6. `/review-best-practices`
-7. `/review-documentation`
-8. `/review-testing`
+For each agent:
+- Read the corresponding skill file from `.claude/skills/review-*/SKILL.md` to get its full prompt
+- Pass the diff/file content as the `$ARGUMENTS` target
+- Use `subagent_type: "Explore"` (they only need read access)
 
-Each runs in its own isolated sub-agent and returns structured findings.
+The 8 skill files to read and dispatch:
+1. `.claude/skills/review-correctness/SKILL.md`
+2. `.claude/skills/review-security/SKILL.md`
+3. `.claude/skills/review-performance/SKILL.md`
+4. `.claude/skills/review-style/SKILL.md`
+5. `.claude/skills/review-composability/SKILL.md`
+6. `.claude/skills/review-best-practices/SKILL.md`
+7. `.claude/skills/review-documentation/SKILL.md`
+8. `.claude/skills/review-testing/SKILL.md`
+
+Each agent's prompt should be the full content of the skill file (everything after the frontmatter `---`) with `$ARGUMENTS` replaced by the actual diff or description of what to review. Tell the agent to run `git diff --cached` (or whatever command resolves the target) to see the code.
 
 ## Step 3: Synthesize
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -59,16 +59,19 @@ Once all sub-reviewers return, produce a unified review:
 ## Code Review: [target]
 
 ### Critical
-- **file:line** — [dimensions] description — suggested fix
+1. **file:line** — [dimensions] description — suggested fix
 
 ### Major
-- **file:line** — [dimensions] description — suggested fix
+N. **file:line** — [dimensions] description — suggested fix
 
 ### Minor
-- **file:line** — [dimensions] description — suggested fix
+N. **file:line** — [dimensions] description — suggested fix
 
 ### Positive
 - Strengths noted across reviews
+
+Number findings sequentially across all severity levels (1, 2, 3...)
+so they can be referenced by number when addressing them.
 
 ---
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: review
+description: Run a multi-dimensional code review using parallel sub-agents
+allowed-tools: Read Glob Grep Bash(git:*) Agent Skill
+arguments:
+  - name: target
+    description: What to review — file paths, a git ref like HEAD~3, a branch name, etc.
+---
+
+# Code Review Orchestrator
+
+You are orchestrating a comprehensive code review. Your job is to resolve the target, dispatch parallel sub-reviewers, and synthesize their findings.
+
+## Target
+
+$ARGUMENTS
+
+## Step 1: Resolve the target
+
+Determine what code to review:
+- If the target looks like a git ref (HEAD~3, a branch name, a commit hash): run `git diff <target>` to get the diff
+- If the target is file paths: read those files
+- If ambiguous, use your best judgment
+
+Capture the diff or file contents — you'll pass this to each sub-reviewer.
+
+## Step 2: Dispatch sub-reviewers
+
+Spawn **all 6** of these sub-reviewer skills in parallel using the Skill tool, passing the diff/file content as the argument to each:
+
+1. `/review-correctness`
+2. `/review-security`
+3. `/review-performance`
+4. `/review-style`
+5. `/review-composability`
+6. `/review-best-practices`
+
+Each runs in its own isolated sub-agent and returns structured findings.
+
+## Step 3: Synthesize
+
+Once all sub-reviewers return, produce a unified review:
+
+1. **Deduplicate**: if multiple reviewers flagged the same issue, merge into one finding and note which dimensions it touches
+2. **Rank by severity**: Critical > Major > Minor, across all dimensions
+3. **Present the unified report** in this format:
+
+---
+
+## Code Review: [target]
+
+### Critical
+- **file:line** — [dimensions] description — suggested fix
+
+### Major
+- **file:line** — [dimensions] description — suggested fix
+
+### Minor
+- **file:line** — [dimensions] description — suggested fix
+
+### Positive
+- Strengths noted across reviews
+
+---
+
+The `[dimensions]` tag shows which review(s) flagged it, e.g. `[security, correctness]`.
+
+Keep the synthesis concise. Don't pad — if the code is clean, say so briefly.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review
 description: Run a multi-dimensional code review using parallel sub-agents
-allowed-tools: Read Glob Grep Bash(git:*) Agent Skill
+allowed-tools: Read Glob Grep Bash(git *) Agent Skill
 arguments:
   - name: target
     description: What to review — file paths, a git ref like HEAD~3, a branch name, etc.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -26,7 +26,7 @@ Capture the diff or file contents — you'll pass this to each sub-reviewer.
 
 ## Step 2: Dispatch sub-reviewers
 
-Spawn **all 6** of these sub-reviewer skills in parallel using the Skill tool, passing the diff/file content as the argument to each:
+Spawn **all 8** of these sub-reviewer skills in parallel using the Skill tool, passing the diff/file content as the argument to each:
 
 1. `/review-correctness`
 2. `/review-security`
@@ -34,6 +34,8 @@ Spawn **all 6** of these sub-reviewer skills in parallel using the Skill tool, p
 4. `/review-style`
 5. `/review-composability`
 6. `/review-best-practices`
+7. `/review-documentation`
+8. `/review-testing`
 
 Each runs in its own isolated sub-agent and returns structured findings.
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -44,8 +44,9 @@ Each runs in its own isolated sub-agent and returns structured findings.
 Once all sub-reviewers return, produce a unified review:
 
 1. **Deduplicate**: if multiple reviewers flagged the same issue, merge into one finding and note which dimensions it touches
-2. **Rank by severity**: Critical > Major > Minor, across all dimensions
-3. **Present the unified report** in this format:
+2. **Include every finding**: every issue from every sub-reviewer must appear in the synthesis. Deduplication merges overlapping findings — it never drops them. If a finding is unique to one reviewer, it still appears.
+3. **Rank by severity**: Critical > Major > Minor, across all dimensions
+4. **Present the unified report** in this format:
 
 ---
 
@@ -67,4 +68,4 @@ Once all sub-reviewers return, produce a unified review:
 
 The `[dimensions]` tag shows which review(s) flagged it, e.g. `[security, correctness]`.
 
-Keep the synthesis concise. Don't pad — if the code is clean, say so briefly.
+Keep each finding concise — one or two sentences. Don't pad — if the code is clean, say so briefly. But never omit a finding for brevity.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -45,7 +45,7 @@ Once all sub-reviewers return, produce a unified review:
 
 1. **Deduplicate**: if multiple reviewers flagged the same issue, merge into one finding and note which dimensions it touches
 2. **Include every finding**: every issue from every sub-reviewer must appear in the synthesis. Deduplication merges overlapping findings — it never drops them. If a finding is unique to one reviewer, it still appears.
-3. **Rank by severity**: Critical > Major > Minor, across all dimensions
+3. **Preserve severity**: use the highest severity any sub-reviewer assigned to a finding. Never downgrade a sub-reviewer's severity — if a reviewer calls something Critical, it stays Critical in the synthesis unless merged with another finding that changes the substance
 4. **Present the unified report** in this format:
 
 ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           extra-conf: |
             extra-substituters = https://cache.iog.io
             extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            allow-import-from-derivation = true
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 .pre-commit-config.yaml
 *.db
 dist
+
+# Claude Code local (per-machine) state
+.claude/settings.local.json
+.claude/worktrees/
+
+# Python analysis artifacts
+__pycache__/
+*.pyc
+analysis/plots/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,20 @@ Runs in order: C library build → C tests → Haskell build → Haskell tests �
 - Pre-commit hooks (via Nix `git-hooks`): no direct commits to master, merge conflict check, commitizen conventional commit format
 - On merge to master: full CI runs automatically
 
+## Change Discipline
+
+All changes follow atomic commit discipline: each commit is one
+coherent idea, ≤200 lines (hard max 400), with tested acceptance
+criteria. Every commit must leave the codebase green — compiles, full
+test suite passes. Full rules live in two skills:
+
+- **`/plan-commits`** — invoke **before starting any implementation
+  work**, even for seemingly single-commit changes. Scope is not
+  always obvious upfront.
+- **`/commit-change`** — invoke when ready to commit. Actively checks
+  diff size, runs the full test suite, and structures the commit
+  message.
+
 ## Cross-Project Changes
 
 When changing the C library's API (`api.h`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,15 @@ Prefer:
 - "Both must run for the SP to be popped." (contract / invariant)
 - "Failure here means the connection state is unknown." (consequence)
 
+## Decision Authority
+
+The user makes all decisions about what to do, what to skip, and
+what approach to take. Never make these decisions independently.
+Present information, ask, and wait. This applies to everything:
+review findings, implementation approaches, whether something is
+"worth it," whether to leave something as-is. If a decision is
+needed, it is the user's decision to make.
+
 ## Testing Requirements
 
 All tests must pass before work is considered complete. Run the full suite:

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -180,7 +180,31 @@ SQLite via `sqlite-simple`. Schema in `db/schema.sql`. Key tables:
 | `game_participant_token` | Auth tokens for game access |
 | `pending_game_action` | Draw offers, undo requests |
 
-Migrations managed via dbmate. Schema version tracked in `schema_migrations`.
+### Migrations (dbmate)
+
+Migrations are managed via [dbmate](https://github.com/amacneil/dbmate). The database URL is configured in `.env` (`sqlite:./db.db`).
+
+**Workflow for adding a migration:**
+
+1. `cd backend && dbmate new <description>` — generates `db/migrations/[TIMESTAMP]_<description>.sql`
+2. Edit the generated file: write SQL in `-- migrate:up` and `-- migrate:down` sections
+3. `dbmate up` — applies pending migrations and auto-regenerates `db/schema.sql`
+4. Commit both the migration file and the updated `db/schema.sql`
+
+**Key commands:**
+
+| Command | Effect |
+|---|---|
+| `dbmate new <name>` | Generate a new migration file with timestamp prefix |
+| `dbmate up` | Create DB if needed, apply pending migrations, dump schema |
+| `dbmate migrate` | Apply pending migrations (DB must exist) |
+| `dbmate rollback` | Revert the most recently applied migration |
+| `dbmate status` | Show applied/pending migrations |
+| `dbmate dump` | Regenerate `db/schema.sql` from current DB state |
+
+**Important:** `db/schema.sql` is a derived artifact — `dbmate up` regenerates it automatically. Tests load this file to create in-memory databases, so it must stay in sync with migrations. Never edit `schema.sql` by hand; always go through the migration workflow.
+
+Schema version tracked in `schema_migrations`.
 
 ## Testing
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -119,6 +119,7 @@ GHC2021 base with these default extensions: `TemplateHaskell`, `OverloadedString
 - **Lenses**: optics library (`^.`, `%~`, etc.)
 - **Warnings**: `-Wall -Werror -Wmissing-export-lists` — every module needs an explicit export list
 - **Formatting**: fourmolu (2-space indent, leading commas, 80-column, trailing arrows, diff-friendly imports)
+- **Type modeling**: Parse, don't validate. Make illegal states unrepresentable. Wrap primitives in newtypes for domain meaning (e.g. `Seconds`, `GameId` — never bare `Int` or `Text`). Use `refined` predicates to encode invariants at the type level. Prefer sum types over booleans or stringly-typed fields. Push validation to the boundary so internal code only handles well-typed values.
 
 ### Common Pitfalls
 
@@ -217,6 +218,8 @@ cabal test --test-option='-p "foo"' # filter by pattern
 
 Test utilities in `test/TestUtil.hs` and `test/Hnefatafl/Game/TestUtil.hs`.
 
-## Don't Change the User's Approach
+## Design Discipline
 
 When implementing solutions, follow the specified approach exactly. If there are issues, fix implementation details rather than changing the approach. Ask before deviating.
+
+Always fix the design, never hack around it. If the types are incomplete, complete them. If the data model doesn't capture the information a function needs, extend the model. Never suggest workarounds that split responsibility, patch state after the fact, or paper over gaps in the type system. There is no "quick option" — there is only the correct fix.

--- a/backend/db/migrations/20260509205633_add_time_control.sql
+++ b/backend/db/migrations/20260509205633_add_time_control.sql
@@ -1,7 +1,7 @@
 -- migrate:up
 
-ALTER TABLE online_game ADD COLUMN initial_seconds INTEGER;
-ALTER TABLE online_game ADD COLUMN increment_seconds INTEGER;
+ALTER TABLE online_game ADD COLUMN initial_seconds INTEGER CHECK (initial_seconds > 0);
+ALTER TABLE online_game ADD COLUMN increment_seconds INTEGER CHECK (increment_seconds >= 0);
 
 -- migrate:down
 

--- a/backend/db/migrations/20260509205633_add_time_control.sql
+++ b/backend/db/migrations/20260509205633_add_time_control.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+
+ALTER TABLE online_game ADD COLUMN initial_seconds INTEGER;
+ALTER TABLE online_game ADD COLUMN increment_seconds INTEGER;
+
+-- migrate:down
+
+ALTER TABLE online_game DROP COLUMN initial_seconds;
+ALTER TABLE online_game DROP COLUMN increment_seconds;

--- a/backend/db/migrations/20260510202140_add_clock_state.sql
+++ b/backend/db/migrations/20260510202140_add_clock_state.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+
+ALTER TABLE online_game ADD COLUMN white_remaining_ns INTEGER CHECK (white_remaining_ns >= 0);
+ALTER TABLE online_game ADD COLUMN black_remaining_ns INTEGER CHECK (black_remaining_ns >= 0);
+ALTER TABLE online_game ADD COLUMN turn_started_at TEXT;
+
+-- migrate:down
+
+ALTER TABLE online_game DROP COLUMN white_remaining_ns;
+ALTER TABLE online_game DROP COLUMN black_remaining_ns;
+ALTER TABLE online_game DROP COLUMN turn_started_at;

--- a/backend/db/migrations/20260517120528_add_timeout_at.sql
+++ b/backend/db/migrations/20260517120528_add_timeout_at.sql
@@ -1,0 +1,8 @@
+-- migrate:up
+ALTER TABLE online_game ADD COLUMN timeout_at TEXT;
+CREATE INDEX idx_online_game_timeout_at ON online_game(timeout_at)
+  WHERE timeout_at IS NOT NULL;
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_online_game_timeout_at;
+ALTER TABLE online_game DROP COLUMN timeout_at;

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -100,7 +100,7 @@ CREATE TABLE online_game (
     white_name TEXT,
     black_player_id TEXT,
     black_name TEXT,
-    game_type TEXT NOT NULL DEFAULT 'online' CHECK (game_type = 'online'), initial_seconds INTEGER CHECK (initial_seconds > 0), increment_seconds INTEGER CHECK (increment_seconds >= 0),
+    game_type TEXT NOT NULL DEFAULT 'online' CHECK (game_type = 'online'), initial_seconds INTEGER CHECK (initial_seconds > 0), increment_seconds INTEGER CHECK (increment_seconds >= 0), white_remaining_ns INTEGER CHECK (white_remaining_ns >= 0), black_remaining_ns INTEGER CHECK (black_remaining_ns >= 0), turn_started_at TEXT,
     FOREIGN KEY (game_id, game_type) REFERENCES game(id, game_type) ON DELETE CASCADE,
     FOREIGN KEY (white_player_id) REFERENCES player(id),
     FOREIGN KEY (black_player_id) REFERENCES player(id)
@@ -110,4 +110,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20251115123657'),
   ('20260330183402'),
   ('20260401080529'),
-  ('20260509205633');
+  ('20260509205633'),
+  ('20260510202140');

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -100,15 +100,18 @@ CREATE TABLE online_game (
     white_name TEXT,
     black_player_id TEXT,
     black_name TEXT,
-    game_type TEXT NOT NULL DEFAULT 'online' CHECK (game_type = 'online'), initial_seconds INTEGER CHECK (initial_seconds > 0), increment_seconds INTEGER CHECK (increment_seconds >= 0), white_remaining_ns INTEGER CHECK (white_remaining_ns >= 0), black_remaining_ns INTEGER CHECK (black_remaining_ns >= 0), turn_started_at TEXT,
+    game_type TEXT NOT NULL DEFAULT 'online' CHECK (game_type = 'online'), initial_seconds INTEGER CHECK (initial_seconds > 0), increment_seconds INTEGER CHECK (increment_seconds >= 0), white_remaining_ns INTEGER CHECK (white_remaining_ns >= 0), black_remaining_ns INTEGER CHECK (black_remaining_ns >= 0), turn_started_at TEXT, timeout_at TEXT,
     FOREIGN KEY (game_id, game_type) REFERENCES game(id, game_type) ON DELETE CASCADE,
     FOREIGN KEY (white_player_id) REFERENCES player(id),
     FOREIGN KEY (black_player_id) REFERENCES player(id)
 );
+CREATE INDEX idx_online_game_timeout_at ON online_game(timeout_at)
+  WHERE timeout_at IS NOT NULL;
 -- Dbmate schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20251115123657'),
   ('20260330183402'),
   ('20260401080529'),
   ('20260509205633'),
-  ('20260510202140');
+  ('20260510202140'),
+  ('20260517120528');

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -100,7 +100,7 @@ CREATE TABLE online_game (
     white_name TEXT,
     black_player_id TEXT,
     black_name TEXT,
-    game_type TEXT NOT NULL DEFAULT 'online' CHECK (game_type = 'online'), initial_seconds INTEGER, increment_seconds INTEGER,
+    game_type TEXT NOT NULL DEFAULT 'online' CHECK (game_type = 'online'), initial_seconds INTEGER CHECK (initial_seconds > 0), increment_seconds INTEGER CHECK (increment_seconds >= 0),
     FOREIGN KEY (game_id, game_type) REFERENCES game(id, game_type) ON DELETE CASCADE,
     FOREIGN KEY (white_player_id) REFERENCES player(id),
     FOREIGN KEY (black_player_id) REFERENCES player(id)

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -100,7 +100,7 @@ CREATE TABLE online_game (
     white_name TEXT,
     black_player_id TEXT,
     black_name TEXT,
-    game_type TEXT NOT NULL DEFAULT 'online' CHECK (game_type = 'online'),
+    game_type TEXT NOT NULL DEFAULT 'online' CHECK (game_type = 'online'), initial_seconds INTEGER, increment_seconds INTEGER,
     FOREIGN KEY (game_id, game_type) REFERENCES game(id, game_type) ON DELETE CASCADE,
     FOREIGN KEY (white_player_id) REFERENCES player(id),
     FOREIGN KEY (black_player_id) REFERENCES player(id)
@@ -109,4 +109,5 @@ CREATE TABLE online_game (
 INSERT INTO "schema_migrations" (version) VALUES
   ('20251115123657'),
   ('20260330183402'),
-  ('20260401080529');
+  ('20260401080529'),
+  ('20260509205633');

--- a/backend/hnefatafl.cabal
+++ b/backend/hnefatafl.cabal
@@ -157,6 +157,7 @@ library
     , temporary
     , text
     , time
+    , torsor
     , transformers
     , uuid-types
     , vty
@@ -246,6 +247,7 @@ library hnefatafl-version
     , temporary
     , text
     , time
+    , torsor
     , transformers
     , uuid-types
     , vty
@@ -335,6 +337,7 @@ executable cli
     , temporary
     , text
     , time
+    , torsor
     , transformers
     , uuid-types
     , vty
@@ -424,6 +427,7 @@ executable dump-specs
     , temporary
     , text
     , time
+    , torsor
     , transformers
     , uuid-types
     , vty
@@ -452,12 +456,14 @@ test-suite hnefatafl-test
       Hnefatafl.Core.DataTest
       Hnefatafl.ExceptionTest
       Hnefatafl.Game.AITest
+      Hnefatafl.Game.ClockTest
       Hnefatafl.Game.HotseatTest
       Hnefatafl.Game.OnlineTest
       Hnefatafl.Game.TestUtil
       Hnefatafl.ImportTest
       Hnefatafl.Interpreter.Search.RemoteTest
       Hnefatafl.Interpreter.Search.TestTest
+      Hnefatafl.Interpreter.Storage.SQLite.ClockStateTest
       Hnefatafl.Interpreter.Storage.SQLite.GameTest
       Hnefatafl.Interpreter.Storage.SQLite.MoveTest
       Hnefatafl.Interpreter.Storage.SQLite.PendingActionTest
@@ -555,6 +561,7 @@ test-suite hnefatafl-test
     , temporary
     , text
     , time
+    , torsor
     , transformers
     , uuid-types
     , vty

--- a/backend/hnefatafl.cabal
+++ b/backend/hnefatafl.cabal
@@ -54,6 +54,7 @@ library
       Hnefatafl.Game.Online
       Hnefatafl.Import
       Hnefatafl.Interpreter.Clock.IO
+      Hnefatafl.Interpreter.Clock.Test
       Hnefatafl.Interpreter.IdGen.UUIDv7
       Hnefatafl.Interpreter.Metrics.NoOp
       Hnefatafl.Interpreter.Search.Local
@@ -449,7 +450,9 @@ test-suite hnefatafl-test
   other-modules:
       Hnefatafl.Api.SpecTest
       Hnefatafl.App.HotseatTest
+      Hnefatafl.App.Online.SerializationTest
       Hnefatafl.App.OnlineCreateTest
+      Hnefatafl.App.OnlineSessionTest
       Hnefatafl.App.TestUtil
       Hnefatafl.BindingsTest
       Hnefatafl.ClientTest

--- a/backend/hnefatafl.cabal
+++ b/backend/hnefatafl.cabal
@@ -457,6 +457,7 @@ test-suite hnefatafl-test
       Hnefatafl.Interpreter.Storage.SQLite.PendingActionTest
       Hnefatafl.Interpreter.Storage.SQLite.PlayerTest
       Hnefatafl.Interpreter.Storage.SQLite.TokenTest
+      Hnefatafl.Interpreter.Storage.SQLite.TransactionTest
       Hnefatafl.Interpreter.Storage.SQLite.Util
       Hnefatafl.QQ.MoveTest
       Hnefatafl.SearchTest

--- a/backend/hnefatafl.cabal
+++ b/backend/hnefatafl.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 
--- This file has been generated from package.yaml by hpack version 0.38.1.
+-- This file has been generated from package.yaml by hpack version 0.38.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -441,6 +441,7 @@ test-suite hnefatafl-test
   other-modules:
       Hnefatafl.Api.SpecTest
       Hnefatafl.App.HotseatTest
+      Hnefatafl.App.OnlineCreateTest
       Hnefatafl.App.TestUtil
       Hnefatafl.BindingsTest
       Hnefatafl.ClientTest
@@ -456,6 +457,7 @@ test-suite hnefatafl-test
       Hnefatafl.Interpreter.Storage.SQLite.MoveTest
       Hnefatafl.Interpreter.Storage.SQLite.PendingActionTest
       Hnefatafl.Interpreter.Storage.SQLite.PlayerTest
+      Hnefatafl.Interpreter.Storage.SQLite.TimeControlTest
       Hnefatafl.Interpreter.Storage.SQLite.TokenTest
       Hnefatafl.Interpreter.Storage.SQLite.TransactionTest
       Hnefatafl.Interpreter.Storage.SQLite.Util

--- a/backend/hnefatafl.cabal
+++ b/backend/hnefatafl.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 
--- This file has been generated from package.yaml by hpack version 0.38.2.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 

--- a/backend/hnefatafl.cabal
+++ b/backend/hnefatafl.cabal
@@ -139,6 +139,7 @@ library
     , optparse-applicative
     , prometheus-client
     , prometheus-metrics-ghc
+    , refined
     , relude
     , resourcet
     , safe-exceptions
@@ -227,6 +228,7 @@ library hnefatafl-version
     , optparse-applicative
     , prometheus-client
     , prometheus-metrics-ghc
+    , refined
     , relude
     , resourcet
     , safe-exceptions
@@ -315,6 +317,7 @@ executable cli
     , optparse-applicative
     , prometheus-client
     , prometheus-metrics-ghc
+    , refined
     , relude
     , resourcet
     , safe-exceptions
@@ -403,6 +406,7 @@ executable dump-specs
     , optparse-applicative
     , prometheus-client
     , prometheus-metrics-ghc
+    , refined
     , relude
     , resourcet
     , safe-exceptions
@@ -445,6 +449,7 @@ test-suite hnefatafl-test
       Hnefatafl.App.TestUtil
       Hnefatafl.BindingsTest
       Hnefatafl.ClientTest
+      Hnefatafl.Core.DataTest
       Hnefatafl.ExceptionTest
       Hnefatafl.Game.AITest
       Hnefatafl.Game.HotseatTest
@@ -527,6 +532,7 @@ test-suite hnefatafl-test
     , process
     , prometheus-client
     , prometheus-metrics-ghc
+    , refined
     , relude
     , resourcet
     , safe-exceptions

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -411,6 +411,25 @@
                 ],
                 "type": "object"
             },
+            "ClockMs": {
+                "properties": {
+                    "blackMs": {
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "type": "integer"
+                    },
+                    "whiteMs": {
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "whiteMs",
+                    "blackMs"
+                ],
+                "type": "object"
+            },
             "CreateAiGameResponse": {
                 "properties": {
                     "gameId": {
@@ -735,6 +754,9 @@
                             "board": {
                                 "$ref": "#/components/schemas/ApiBoard"
                             },
+                            "clock": {
+                                "$ref": "#/components/schemas/ClockMs"
+                            },
                             "gameId": {
                                 "$ref": "#/components/schemas/GameId"
                             },
@@ -784,6 +806,9 @@
                             "board": {
                                 "$ref": "#/components/schemas/ApiBoard"
                             },
+                            "clock": {
+                                "$ref": "#/components/schemas/ClockMs"
+                            },
                             "move": {
                                 "$ref": "#/components/schemas/ApiMove"
                             },
@@ -820,6 +845,9 @@
                     },
                     {
                         "properties": {
+                            "clock": {
+                                "$ref": "#/components/schemas/ClockMs"
+                            },
                             "status": {
                                 "$ref": "#/components/schemas/ApiGameStatus"
                             },
@@ -910,6 +938,9 @@
                             "board": {
                                 "$ref": "#/components/schemas/ApiBoard"
                             },
+                            "clock": {
+                                "$ref": "#/components/schemas/ClockMs"
+                            },
                             "moveCount": {
                                 "maximum": 9223372036854775807,
                                 "minimum": -9223372036854775808,
@@ -970,6 +1001,33 @@
                             "type"
                         ],
                         "title": "OnlineUndoCancelled",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "blackMs": {
+                                "maximum": 9223372036854775807,
+                                "minimum": -9223372036854775808,
+                                "type": "integer"
+                            },
+                            "type": {
+                                "enum": [
+                                    "clockUpdated"
+                                ],
+                                "type": "string"
+                            },
+                            "whiteMs": {
+                                "maximum": 9223372036854775807,
+                                "minimum": -9223372036854775808,
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "whiteMs",
+                            "blackMs",
+                            "type"
+                        ],
+                        "title": "OnlineClockUpdated",
                         "type": "object"
                     },
                     {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -418,6 +418,11 @@
                         "minimum": -9223372036854775808,
                         "type": "integer"
                     },
+                    "turnStartedAtMs": {
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "type": "integer"
+                    },
                     "whiteMs": {
                         "maximum": 9223372036854775807,
                         "minimum": -9223372036854775808,
@@ -426,7 +431,8 @@
                 },
                 "required": [
                     "whiteMs",
-                    "blackMs"
+                    "blackMs",
+                    "turnStartedAtMs"
                 ],
                 "type": "object"
             },
@@ -1010,6 +1016,11 @@
                                 "minimum": -9223372036854775808,
                                 "type": "integer"
                             },
+                            "turnStartedAtMs": {
+                                "maximum": 9223372036854775807,
+                                "minimum": -9223372036854775808,
+                                "type": "integer"
+                            },
                             "type": {
                                 "enum": [
                                     "clockUpdated"
@@ -1025,6 +1036,7 @@
                         "required": [
                             "whiteMs",
                             "blackMs",
+                            "turnStartedAtMs",
                             "type"
                         ],
                         "title": "OnlineClockUpdated",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -437,6 +437,14 @@
                 ],
                 "type": "object"
             },
+            "CreateOnlineGameRequest": {
+                "properties": {
+                    "timeControl": {
+                        "$ref": "#/components/schemas/TimeControl"
+                    }
+                },
+                "type": "object"
+            },
             "CreateOnlineGameResponse": {
                 "properties": {
                     "blackToken": {
@@ -1091,6 +1099,25 @@
                 ],
                 "type": "object"
             },
+            "TimeControl": {
+                "properties": {
+                    "increment": {
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "type": "integer"
+                    },
+                    "initialTime": {
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "initialTime",
+                    "increment"
+                ],
+                "type": "object"
+            },
             "ValidMovesMap": {
                 "additionalProperties": {
                     "items": {
@@ -1409,6 +1436,15 @@
         },
         "/online": {
             "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json;charset=utf-8": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateOnlineGameRequest"
+                            }
+                        }
+                    }
+                },
                 "responses": {
                     "200": {
                         "content": {
@@ -1419,6 +1455,9 @@
                             }
                         },
                         "description": ""
+                    },
+                    "400": {
+                        "description": "Invalid `body`"
                     }
                 }
             }

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1103,12 +1103,12 @@
                 "properties": {
                     "increment": {
                         "maximum": 9223372036854775807,
-                        "minimum": -9223372036854775808,
+                        "minimum": 0,
                         "type": "integer"
                     },
                     "initialTime": {
                         "maximum": 9223372036854775807,
-                        "minimum": -9223372036854775808,
+                        "minimum": 1,
                         "type": "integer"
                     }
                 },

--- a/backend/package.yaml
+++ b/backend/package.yaml
@@ -100,6 +100,7 @@ dependencies:
   - wai-websockets
   - resourcet
   - openapi3
+  - refined
   - servant-openapi3
   - katip
   - katip-effectful

--- a/backend/package.yaml
+++ b/backend/package.yaml
@@ -72,6 +72,7 @@ dependencies:
   - aeson
   - aeson-pretty
   - chronos
+  - torsor
   - template-haskell
   - safe-exceptions
   - servant

--- a/backend/src/Hnefatafl/Api/Handlers/Online.hs
+++ b/backend/src/Hnefatafl/Api/Handlers/Online.hs
@@ -8,6 +8,7 @@ import Effectful.Error.Static (Error)
 import Effectful.Katip (KatipE, katipAddNamespace)
 import Hnefatafl.Api.Routes.Online (OnlineRoutes (..))
 import Hnefatafl.Api.Types.Online (
+  CreateOnlineGameRequest (..),
   CreateOnlineGameResponse (..),
  )
 import Hnefatafl.App.Online qualified as Online
@@ -46,10 +47,17 @@ onlineServer sessions =
     }
 
 createHandler ::
-  (Storage :> es, Clock :> es, IdGen :> es, KatipE :> es, Trace :> es, HMetrics :> es) =>
+  ( Storage :> es
+  , Clock :> es
+  , IdGen :> es
+  , KatipE :> es
+  , Trace :> es
+  , HMetrics :> es
+  ) =>
+  CreateOnlineGameRequest ->
   Eff es CreateOnlineGameResponse
-createHandler = katipAddNamespace "online" $ do
-  result <- Online.createGame
+createHandler req = katipAddNamespace "online" $ do
+  result <- Online.createGame req.timeControl
   pure
     CreateOnlineGameResponse
       { gameId = result.game.gameId

--- a/backend/src/Hnefatafl/Api/Routes/Online.hs
+++ b/backend/src/Hnefatafl/Api/Routes/Online.hs
@@ -5,17 +5,23 @@ module Hnefatafl.Api.Routes.Online (
   OnlineRoutes (..),
 ) where
 
-import Hnefatafl.Api.Types.Online (CreateOnlineGameResponse)
+import Hnefatafl.Api.Types.Online (
+  CreateOnlineGameRequest,
+  CreateOnlineGameResponse,
+ )
 import Hnefatafl.Servant.WebSocket (WebSocket)
 import Servant (
   GenericMode (type (:-)),
   JSON,
   Post,
+  ReqBody,
  )
 import Servant.API ((:>))
 
 data OnlineRoutes mode = OnlineRoutes
-  { create :: mode :- Post '[JSON] CreateOnlineGameResponse
+  { create ::
+      mode
+        :- ReqBody '[JSON] CreateOnlineGameRequest :> Post '[JSON] CreateOnlineGameResponse
   , ws :: mode :- "ws" :> WebSocket
   }
   deriving stock (Generic)

--- a/backend/src/Hnefatafl/Api/Types/Online.hs
+++ b/backend/src/Hnefatafl/Api/Types/Online.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 
 module Hnefatafl.Api.Types.Online (
+  CreateOnlineGameRequest (..),
   CreateOnlineGameResponse (..),
 ) where
 
@@ -8,7 +9,14 @@ import Data.Aeson (FromJSON, ToJSON)
 import Data.OpenApi (ToSchema)
 import Hnefatafl.Core.Data (
   GameId,
+  TimeControl,
  )
+
+data CreateOnlineGameRequest = CreateOnlineGameRequest
+  { timeControl :: Maybe TimeControl
+  }
+  deriving stock (Generic, Show)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data CreateOnlineGameResponse = CreateOnlineGameResponse
   { gameId :: GameId

--- a/backend/src/Hnefatafl/Api/Types/WS/Online.hs
+++ b/backend/src/Hnefatafl/Api/Types/WS/Online.hs
@@ -54,6 +54,7 @@ onlineOptions =
 data ClockMs = ClockMs
   { _whiteMs :: Int
   , _blackMs :: Int
+  , _turnStartedAtMs :: Int
   }
   deriving (Show, Eq, Generic)
 
@@ -115,6 +116,7 @@ data OnlineServerMessage
   | OnlineClockUpdated
       { _whiteMs :: Int
       , _blackMs :: Int
+      , _turnStartedAtMs :: Int
       }
   | OnlineOpponentJoined
   | OnlineOpponentLeft

--- a/backend/src/Hnefatafl/Api/Types/WS/Online.hs
+++ b/backend/src/Hnefatafl/Api/Types/WS/Online.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 
 module Hnefatafl.Api.Types.WS.Online (
+  ClockMs (..),
   OnlineServerMessage (..),
   OnlineClientMessage (..),
   onlineOptions,
@@ -48,6 +49,24 @@ onlineOptions =
     }
 
 -------------------------------------------------------------------------------
+-- Clock
+
+data ClockMs = ClockMs
+  { _whiteMs :: Int
+  , _blackMs :: Int
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON ClockMs where
+  toJSON = genericToJSON defaultOptions{Aeson.fieldLabelModifier = drop 1}
+instance FromJSON ClockMs where
+  parseJSON = genericParseJSON defaultOptions{Aeson.fieldLabelModifier = drop 1}
+instance ToSchema ClockMs where
+  declareNamedSchema =
+    genericDeclareNamedSchema
+      (fromAesonOptions defaultOptions{Aeson.fieldLabelModifier = drop 1})
+
+-------------------------------------------------------------------------------
 -- Server → Client
 
 data OnlineServerMessage
@@ -60,8 +79,7 @@ data OnlineServerMessage
       , _status :: ApiGameStatus
       , _validMoves :: ValidMovesMap
       , _pendingAction :: Maybe PendingActionPayload
-      , _whiteRemainingMs :: Maybe Int
-      , _blackRemainingMs :: Maybe Int
+      , _clock :: Maybe ClockMs
       }
   | OnlineMoveMade
       { _move :: ApiMove
@@ -70,13 +88,11 @@ data OnlineServerMessage
       , _status :: ApiGameStatus
       , _validMoves :: ValidMovesMap
       , _board :: ApiBoard
-      , _whiteRemainingMs :: Maybe Int
-      , _blackRemainingMs :: Maybe Int
+      , _clock :: Maybe ClockMs
       }
   | OnlineGameOver
       { _status :: ApiGameStatus
-      , _whiteRemainingMs :: Maybe Int
-      , _blackRemainingMs :: Maybe Int
+      , _clock :: Maybe ClockMs
       }
   | OnlineDrawOffered
       { _by :: PlayerColor
@@ -92,8 +108,7 @@ data OnlineServerMessage
       , _status :: ApiGameStatus
       , _validMoves :: ValidMovesMap
       , _board :: ApiBoard
-      , _whiteRemainingMs :: Maybe Int
-      , _blackRemainingMs :: Maybe Int
+      , _clock :: Maybe ClockMs
       }
   | OnlineUndoDeclined
   | OnlineUndoCancelled

--- a/backend/src/Hnefatafl/Api/Types/WS/Online.hs
+++ b/backend/src/Hnefatafl/Api/Types/WS/Online.hs
@@ -60,6 +60,8 @@ data OnlineServerMessage
       , _status :: ApiGameStatus
       , _validMoves :: ValidMovesMap
       , _pendingAction :: Maybe PendingActionPayload
+      , _whiteRemainingMs :: Maybe Int
+      , _blackRemainingMs :: Maybe Int
       }
   | OnlineMoveMade
       { _move :: ApiMove
@@ -68,9 +70,13 @@ data OnlineServerMessage
       , _status :: ApiGameStatus
       , _validMoves :: ValidMovesMap
       , _board :: ApiBoard
+      , _whiteRemainingMs :: Maybe Int
+      , _blackRemainingMs :: Maybe Int
       }
   | OnlineGameOver
       { _status :: ApiGameStatus
+      , _whiteRemainingMs :: Maybe Int
+      , _blackRemainingMs :: Maybe Int
       }
   | OnlineDrawOffered
       { _by :: PlayerColor
@@ -86,9 +92,15 @@ data OnlineServerMessage
       , _status :: ApiGameStatus
       , _validMoves :: ValidMovesMap
       , _board :: ApiBoard
+      , _whiteRemainingMs :: Maybe Int
+      , _blackRemainingMs :: Maybe Int
       }
   | OnlineUndoDeclined
   | OnlineUndoCancelled
+  | OnlineClockUpdated
+      { _whiteMs :: Int
+      , _blackMs :: Int
+      }
   | OnlineOpponentJoined
   | OnlineOpponentLeft
   deriving (Show, Eq, Generic)

--- a/backend/src/Hnefatafl/App/AI.hs
+++ b/backend/src/Hnefatafl/App/AI.hs
@@ -112,7 +112,7 @@ data GameSession = GameSession
   }
   deriving (Generic)
 
-type GameSessions = STMMap.Map GameId (SessionEntry GameSession)
+type GameSessions = STMMap.Map GameId (SessionEntry (MVar GameSession))
 
 -------------------------------------------------------------------------------
 -- Client message conversion
@@ -236,10 +236,13 @@ connectToGame sessions gameId humanColor uid conn = do
       gameState <- runTransaction $ loadAIState humanColor gameId
       let session = GameSession gameState humanColor (uid, connVar) Nothing
       var <- MVar.newMVar session
-      sessionVar <- STM.atomically $ insertOrAcquire var gameId sessions
+      -- insertOrAcquire is atomic: if another thread raced us and
+      -- inserted first, we acquire their entry instead. Only the
+      -- winner (inserted = True) performs one-time session setup.
+      (sessionVar, inserted) <- STM.atomically $ insertOrAcquire var gameId sessions
       ( do
           -- If engine was thinking (e.g. server restart), re-trigger the search
-          when (sessionVar == var) $
+          when inserted $
             case gameState of
               AI.State _ ms (AI.EngineThinking _) -> do
                 searchAsync <-
@@ -330,7 +333,8 @@ processEvent sessionVar gameId event =
       for_ session.engineAsync Async.cancel
     engineAsync' <-
       if not wasThinking && nowThinking
-        then Just <$> spawnEngineSearch sessionVar gameId session.humanColor newState.moves
+        then
+          Just <$> spawnEngineSearch sessionVar gameId session.humanColor newState.moves
         else pure Nothing
     pure session{gameState = newState, engineAsync = engineAsync'}
 

--- a/backend/src/Hnefatafl/App/AI/Serialization.hs
+++ b/backend/src/Hnefatafl/App/AI/Serialization.hs
@@ -43,6 +43,7 @@ notificationsFor humanColor newState = concatMap $ \case
   UndoDeclined -> []
   OfferCancelled -> []
   OfferAutoCancelled _ _ -> []
+  ClockUpdated _ -> []
  where
   engineMovedMsg am =
     let (turn', status', validMoves', board') = activeStateFields humanColor newState
@@ -71,7 +72,10 @@ gameStateMessage gId humanColor (AI.State board moves phase) =
     { _gameId = gId
     , _playerColor = humanColor
     , _board = boardFromExtern board
-    , _history = map (\am -> historyEntryFromDomain (MoveWithCaptures am.move am.captures) am.side) moves
+    , _history =
+        map
+          (\am -> historyEntryFromDomain (MoveWithCaptures am.move am.captures) am.side)
+          moves
     , _turn = turn'
     , _status = status'
     , _validMoves = validMoves'
@@ -100,7 +104,8 @@ gameStateMessage gId humanColor (AI.State board moves phase) =
       )
 
 -- | Extract common state fields from an AI state.
-activeStateFields :: PlayerColor -> AI.State -> (PlayerColor, ApiGameStatus, ValidMovesMap, ApiBoard)
+activeStateFields ::
+  PlayerColor -> AI.State -> (PlayerColor, ApiGameStatus, ValidMovesMap, ApiBoard)
 activeStateFields humanColor (AI.State board _moves phase) =
   let engineColor = opponent humanColor
    in case phase of

--- a/backend/src/Hnefatafl/App/Online.hs
+++ b/backend/src/Hnefatafl/App/Online.hs
@@ -57,6 +57,7 @@ import Hnefatafl.Core.Data (
   GameParticipantToken (..),
   GameParticipantTokenId (..),
   PlayerColor (..),
+  TimeControl,
   opponent,
  )
 import Hnefatafl.Core.Data qualified as Data
@@ -71,6 +72,7 @@ import Hnefatafl.Effect.Storage (
   getPendingAction,
   insertGame,
   runTransaction,
+  setOnlineTimeControl,
  )
 import Hnefatafl.Effect.Trace (Trace)
 import Hnefatafl.Effect.WebSocket (WebSocket)
@@ -188,8 +190,9 @@ data CreateGameResult = CreateGameResult
 -- Does NOT create a session in the STMMap (lazy creation on WS connect).
 createGame ::
   (Storage :> es, Clock :> es, IdGen :> es, Trace :> es, HMetrics :> es) =>
+  Maybe TimeControl ->
   Eff es CreateGameResult
-createGame = do
+createGame timeControl = do
   game <- mkGame <$> generateId <*> now
   whiteTokenId <- generateId
   blackTokenId <- generateId
@@ -213,6 +216,7 @@ createGame = do
     insertGame game
     createGameParticipantToken whiteToken
     createGameParticipantToken blackToken
+    for_ timeControl $ setOnlineTimeControl game.gameId
   increaseLabelledCounter gamesCreated "online"
   pure CreateGameResult{game, whiteToken, blackToken}
 

--- a/backend/src/Hnefatafl/App/Online.hs
+++ b/backend/src/Hnefatafl/App/Online.hs
@@ -2,16 +2,14 @@
 {-# LANGUAGE DeriveAnyClass #-}
 
 module Hnefatafl.App.Online (
-  GameSession (..),
+  -- * Public API
   GameSessions,
   CreateGameResult (..),
-  toEvent,
   createGame,
-  getOrCreateSession,
-  processEvent,
-  connectPlayer,
-  disconnectPlayer,
   handleWebSocket,
+
+  -- * Internals (exported for testing)
+  SessionEvent (..),
 ) where
 
 import Chronos (Time)
@@ -20,12 +18,15 @@ import Data.Aeson (
  )
 import Effectful (Eff, IOE, (:>))
 import Effectful.Concurrent (Concurrent)
+import Effectful.Concurrent.Async qualified as Async
 import Effectful.Concurrent.MVar qualified as MVar
 import Effectful.Concurrent.STM qualified as STM
-import Effectful.Exception (bracket)
+import Effectful.Exception (bracket, catchSync, throwIO)
 import Effectful.Katip (KatipE, katipAddNamespace, logTM)
 import Hnefatafl.Api.Types (Position (..))
 import Hnefatafl.Api.Types.WS (
+  WsError (..),
+  WsErrorCode (..),
   transitionErrorToWsError,
  )
 import Hnefatafl.Api.Types.WS.Online (
@@ -79,8 +80,18 @@ import Hnefatafl.Effect.Storage (
   setOnlineClockState,
   setOnlineTimeControl,
  )
-import Hnefatafl.Effect.Trace (Trace)
+import Hnefatafl.Effect.Trace (
+  Trace,
+  inSpan,
+  inSpanWithLink,
+  recordSpanException,
+ )
 import Hnefatafl.Effect.WebSocket (WebSocket)
+import Hnefatafl.Exception (
+  DomainException (..),
+  IsDomainException (..),
+  logCaughtException,
+ )
 import Hnefatafl.Game.Common (
   currentBoard,
  )
@@ -97,7 +108,9 @@ import Hnefatafl.Metrics (
  )
 import Katip (Severity (..))
 import Network.WebSockets (Connection)
-import Optics ((.~))
+import OpenTelemetry.Context (lookupSpan)
+import OpenTelemetry.Context.ThreadLocal qualified as ThreadLocal
+import OpenTelemetry.Trace.Core qualified as OT (getSpanContext)
 import StmContainers.Map qualified as STMMap
 
 -------------------------------------------------------------------------------
@@ -106,9 +119,18 @@ import StmContainers.Map qualified as STMMap
 newtype ConnectionId = ConnectionId Text
   deriving (Eq)
 
--- | In-memory session for an active online game. Connections are wrapped
--- in MVars to ensure thread-safe sends — only one thread can write to a
--- WebSocket connection at a time.
+-- | Events processed by the session worker loop. All session state
+-- mutations flow through this queue, ensuring sequential processing
+-- without locks.
+data SessionEvent
+  = PlayerMessage PlayerColor Time OnlineClientMessage
+  | PlayerConnected PlayerColor ConnectionId (MVar Connection)
+  | PlayerDisconnected PlayerColor ConnectionId
+
+-- | In-memory session for an active online game. A session exists
+-- while at least one player is connected; the underlying game
+-- persists in the database across sessions. Owned exclusively by the
+-- worker loop, must never be shared.
 data GameSession = GameSession
   { gameState :: Online.State
   , whiteConn :: Maybe (ConnectionId, MVar Connection)
@@ -116,7 +138,7 @@ data GameSession = GameSession
   }
   deriving (Generic)
 
-type GameSessions = STMMap.Map GameId (SessionEntry GameSession)
+type GameSessions = STMMap.Map GameId (SessionEntry (STM.TBQueue SessionEvent))
 
 -- Convenience helpers
 
@@ -138,11 +160,20 @@ getConn :: PlayerColor -> GameSession -> Maybe (ConnectionId, MVar Connection)
 getConn White session = session.whiteConn
 getConn Black session = session.blackConn
 
+eventColor :: SessionEvent -> PlayerColor
+eventColor (PlayerMessage c _ _) = c
+eventColor (PlayerConnected c _ _) = c
+eventColor (PlayerDisconnected c _) = c
+
+isFinished :: Online.State -> Bool
+isFinished (Online.State _ _ (Online.Finished _)) = True
+isFinished _ = False
+
 -------------------------------------------------------------------------------
 -- Client message conversion
 
--- | Convert an API client message to an Online event, adding the player's
--- color and the current time.
+-- | Convert an API client message to an Online event, adding the
+-- player's color and the current time.
 toEvent :: PlayerColor -> Time -> OnlineClientMessage -> Online.Event
 toEvent color time = \case
   OnlineMove (Position from) (Position to) ->
@@ -195,8 +226,8 @@ data CreateGameResult = CreateGameResult
   , blackToken :: GameParticipantToken
   }
 
--- | Create a new online game in the database with tokens for both players.
--- Does NOT create a session in the STMMap (lazy creation on WS connect).
+-- | Create a new online game in the database with tokens for both
+-- players. Does NOT create a session (lazy creation on WS connect).
 createGame ::
   (Storage :> es, Clock :> es, IdGen :> es, Trace :> es, HMetrics :> es) =>
   Maybe TimeControl ->
@@ -236,57 +267,87 @@ createGame timeControl = do
 -------------------------------------------------------------------------------
 -- Session management
 
--- | Get or create a session. If a session already exists in the map,
--- acquires it (fast path, no DB load). Otherwise loads from DB, creates
--- a full MVar, and inserts it. If two threads race on creation, one
--- wins and the other's work is discarded (optimistic concurrency).
+-- | Get or create a session's event queue. If a session already
+-- exists in the map, acquires it (increments refcount). Otherwise
+-- loads from DB, creates a queue, spawns a worker, and inserts.
 getOrCreateSession ::
-  (Storage :> es, Concurrent :> es, Trace :> es) =>
+  ( Storage :> es
+  , Concurrent :> es
+  , IOE :> es
+  , Clock :> es
+  , WebSocket :> es
+  , KatipE :> es
+  , Trace :> es
+  , HMetrics :> es
+  ) =>
   GameSessions ->
   GameId ->
-  Eff es (MVar GameSession)
+  Eff es (STM.TBQueue SessionEvent)
 getOrCreateSession sessions gameId = do
-  mVar <- STM.atomically $ tryAcquire gameId sessions
-  case mVar of
-    Just var -> pure var
+  existing <- STM.atomically $ tryAcquire gameId sessions
+  case existing of
+    Just queue -> pure queue
     Nothing -> do
       gameState <- runTransaction $ loadOnlineState gameId
-      var <- MVar.newMVar (GameSession gameState Nothing Nothing)
-      STM.atomically $ insertOrAcquire var gameId sessions
-
--- | Register a connection in the session. Wraps the raw Connection in an
--- MVar and returns it alongside the game state for initial send.
-connectPlayer ::
-  Concurrent :> es =>
-  MVar GameSession ->
-  PlayerColor ->
-  ConnectionId ->
-  Connection ->
-  Eff es (MVar Connection, Online.State)
-connectPlayer sessionVar color uid conn = do
-  connVar <- MVar.newMVar conn
-  MVar.modifyMVar sessionVar $ \session ->
-    let session' = setConn color (Just (uid, connVar)) session
-     in pure (session', (connVar, session'.gameState))
-
--- | Unregister a connection from the session. Only clears if the uid
--- matches, so a stale finally from a reconnected player won't remove
--- the new connection. Map lifecycle is handled separately by
--- release in the finally block.
-disconnectPlayer ::
-  Concurrent :> es =>
-  MVar GameSession ->
-  PlayerColor ->
-  ConnectionId ->
-  Eff es ()
-disconnectPlayer sessionVar color uid =
-  MVar.modifyMVar_ sessionVar $ \session ->
-    pure $ clearConn color uid session
+      -- Arbitrary limit: permissive enough to avoid backpressure
+      -- under normal play, small enough to prevent abuse or
+      -- pathological memory growth.
+      -- Two threads can race past the tryAcquire above if neither
+      -- finds an existing entry. Both load state and create a queue,
+      -- but insertOrAcquire is atomic: only one insert wins, the
+      -- other acquires the winner's queue. The Bool distinguishes
+      -- the winner (who must spawn the worker) from the loser
+      -- (whose queue is discarded by insertOrAcquire).
+      (queue, inserted) <- STM.atomically $ do
+        q <- STM.newTBQueue 20
+        insertOrAcquire q gameId sessions
+      when inserted $
+        spawnWorker gameId gameState queue
+      pure queue
 
 -------------------------------------------------------------------------------
--- Event processing
+-- Session worker
 
-processEvent ::
+-- | Spawn the session worker thread. The worker processes all
+-- session events sequentially from the queue, so game state
+-- transitions never race. The worker's root span links back to
+-- the connection that spawned it for traceability.
+spawnWorker ::
+  ( Storage :> es
+  , Clock :> es
+  , Concurrent :> es
+  , IOE :> es
+  , WebSocket :> es
+  , KatipE :> es
+  , Trace :> es
+  , HMetrics :> es
+  ) =>
+  GameId ->
+  Online.State ->
+  STM.TBQueue SessionEvent ->
+  Eff es ()
+spawnWorker gameId initialState queue = do
+  -- Capture the spawning span's context for the link. The worker
+  -- creates its own root span rather than inheriting the parent,
+  -- since it outlives the spawning connection and serves both players.
+  mSpanCtx <- liftIO $ do
+    ctx <- ThreadLocal.getContext
+    traverse OT.getSpanContext (lookupSpan ctx)
+  void $
+    Async.async $
+      katipAddNamespace "online" $
+        katipAddNamespace "worker" $
+          case mSpanCtx of
+            Just spanCtx ->
+              inSpanWithLink "online.session" spanCtx $
+                workerLoop gameId queue (GameSession initialState Nothing Nothing)
+            Nothing ->
+              inSpan "online.session" $
+                workerLoop gameId queue (GameSession initialState Nothing Nothing)
+
+-- | Process events from the queue until the game is finished and
+-- both players have disconnected.
+workerLoop ::
   ( Storage :> es
   , Clock :> es
   , Concurrent :> es
@@ -295,41 +356,128 @@ processEvent ::
   , Trace :> es
   , HMetrics :> es
   ) =>
-  MVar GameSession ->
+  GameId ->
+  STM.TBQueue SessionEvent ->
+  GameSession ->
+  Eff es ()
+workerLoop gameId queue session = do
+  event <- STM.atomically $ STM.readTBQueue queue
+  session' <- handleSessionEvent gameId session event
+  let noConnections =
+        isNothing session'.whiteConn
+          && isNothing session'.blackConn
+      done = isFinished session'.gameState || noConnections
+  unless done $
+    workerLoop gameId queue session'
+
+-- | Dispatch a session event. Non-fatal domain exceptions are
+-- absorbed (logged + reported to the acting player) so the worker
+-- stays alive. Fatal exceptions propagate and kill the worker.
+handleSessionEvent ::
+  ( Storage :> es
+  , Clock :> es
+  , Concurrent :> es
+  , WebSocket :> es
+  , KatipE :> es
+  , Trace :> es
+  , HMetrics :> es
+  ) =>
+  GameId ->
+  GameSession ->
+  SessionEvent ->
+  Eff es GameSession
+handleSessionEvent gameId session event =
+  inSpan "session.event" (dispatchEvent gameId session event)
+    `catchSync` \(ex :: SomeException) ->
+      case fromException @DomainException ex of
+        Just (DomainException e) | not (domainFatal e) -> do
+          logCaughtException ex
+          recordSpanException ex
+          for_ (snd <$> getConn (eventColor event) session) $ \cv ->
+            safeSend cv (encode $ WsError InternalError "internal error" False)
+          pure session
+        _ -> throwIO ex
+
+-- | Route a session event to its handler. Connection events update
+-- the session's connection state and notify the opponent; player
+-- messages drive game state transitions via processGameEvent.
+dispatchEvent ::
+  ( Storage :> es
+  , Clock :> es
+  , Concurrent :> es
+  , WebSocket :> es
+  , KatipE :> es
+  , Trace :> es
+  , HMetrics :> es
+  ) =>
+  GameId ->
+  GameSession ->
+  SessionEvent ->
+  Eff es GameSession
+dispatchEvent gameId session = \case
+  PlayerConnected color connId connVar -> do
+    let session' = setConn color (Just (connId, connVar)) session
+    safeSend connVar (encode $ gameStateMessage gameId color session'.gameState)
+    sendToPlayer (opponent color) (encode OnlineOpponentJoined) session'
+    pure session'
+  PlayerDisconnected color connId -> do
+    let session' = clearConn color connId session
+    sendToPlayer (opponent color) (encode OnlineOpponentLeft) session'
+    pure session'
+  PlayerMessage color time clientMsg ->
+    processGameEvent session gameId color time clientMsg
+
+-------------------------------------------------------------------------------
+-- Game event processing
+
+-- | Process a game event from a player. Transitions state, persists
+-- to DB, sends notifications, and records metrics. Not thread-safe.
+processGameEvent ::
+  ( Storage :> es
+  , Clock :> es
+  , Concurrent :> es
+  , WebSocket :> es
+  , KatipE :> es
+  , Trace :> es
+  , HMetrics :> es
+  ) =>
+  GameSession ->
   GameId ->
   PlayerColor ->
+  Time ->
   OnlineClientMessage ->
-  Eff es ()
-processEvent sessionVar gameId color clientMsg = do
-  currentTime <- now
+  Eff es GameSession
+processGameEvent session gameId color currentTime clientMsg = do
   let event = toEvent color currentTime clientMsg
-  -- All effects (DB writes, notifications) run under the MVar lock so that
-  -- no concurrent event can observe or act on intermediate state.
-  MVar.modifyMVar_ sessionVar $ \session ->
-    case Online.transition session.gameState event of
-      Left err -> do
-        when (err == Common.InvalidMove) $
-          increaseLabelledCounter invalidMovesTotal "online"
-        sendToPlayer
-          color
-          (encode $ transitionErrorToWsError err)
-          session
-        pure session
-      Right (TransitionResult newState events) -> do
-        runTransaction $ persistEvents gameId currentTime events
-        sendNotifications color newState events session
-        recordMetrics "online" events
-        pure $ session & #gameState .~ newState
+  case Online.transition session.gameState event of
+    Left err -> do
+      when (err == Common.InvalidMove) $
+        increaseLabelledCounter invalidMovesTotal "online"
+      sendToPlayer
+        color
+        (encode $ transitionErrorToWsError err)
+        session
+      pure session
+    Right (TransitionResult newState events) -> do
+      runTransaction $ persistEvents gameId currentTime events
+      sendNotifications color newState events session
+      recordMetrics "online" events
+      pure session{gameState = newState}
 
--- | Send all notifications derived from domain events to the appropriate players.
+-- | Send all notifications derived from domain events to the
+-- appropriate players.
 sendNotifications ::
   (Concurrent :> es, WebSocket :> es) =>
-  PlayerColor -> Online.State -> [Common.DomainEvent] -> GameSession -> Eff es ()
+  PlayerColor ->
+  Online.State ->
+  [Common.DomainEvent] ->
+  GameSession ->
+  Eff es ()
 sendNotifications actor newState events session =
   for_ (notificationsFor actor newState events) $ \(target, msg) ->
     sendToPlayer target (encode msg) session
 
--- | Send a message to a player's WebSocket connection, if connected.
+-- | Send a message to a player's connection, if connected.
 sendToPlayer ::
   (Concurrent :> es, WebSocket :> es) =>
   PlayerColor -> LByteString -> GameSession -> Eff es ()
@@ -359,11 +507,15 @@ handleWebSocket sessions conn =
     authenticateWebSocket conn
       >>= traverse_ (handleAuthenticated sessions conn)
 
--- | Run the online game session for an already-authenticated player. Takes
--- the resolved token, opens the session (incrementing the refcount), and
--- runs the receive loop until the WebSocket exits or errors. 'bracket'
--- ensures the refcount is released on any exit path, including failures
--- during connection setup.
+-- | Run the online game handler for an authenticated player. Gets
+-- the session's event queue and enqueues connect/disconnect/message
+-- events. The session worker processes them sequentially.
+--
+-- Uses 'bracket' (not 'finally') so that a failure during connect
+-- (after getOrCreateSession has incremented the refcount) still
+-- releases the refcount in disconnect. The PlayerDisconnected
+-- enqueue is safe even if PlayerConnected never reached the
+-- worker — clearConn is a no-op when the uid doesn't match.
 handleAuthenticated ::
   ( Storage :> es
   , Clock :> es
@@ -379,13 +531,6 @@ handleAuthenticated ::
   Connection ->
   GameParticipantToken ->
   Eff es ()
--- Game context wraps guardWebSocket so that any exception the outer guard
--- catches is still logged with gameId/player context. 'bracket' (not
--- 'finally') is required so that a failure in the acquire path (e.g.
--- connectPlayer throws after getOrCreateSession has incremented the
--- refcount) still releases the refcount. 'disconnectPlayer' is a no-op
--- when the uid doesn't match the stored connection, so it is safe to
--- call even when connectPlayer never completed.
 handleAuthenticated sessions conn tok =
   withGameContext gameId color $
     guardWebSocket conn $
@@ -394,28 +539,22 @@ handleAuthenticated sessions conn tok =
   gameId = tok.gameId
   color = tok.role
   connect = do
-    sessionVar <- getOrCreateSession sessions gameId
+    queue <- getOrCreateSession sessions gameId
     uid <- generateId
-    (connVar, gameState) <-
-      connectPlayer sessionVar color uid conn
-    safeSend
-      connVar
-      (encode $ gameStateMessage gameId color gameState)
-    -- Notify the opponent that this player has joined
-    MVar.withMVar sessionVar $
-      sendToPlayer (opponent color) (encode OnlineOpponentJoined)
+    connVar <- MVar.newMVar conn
+    STM.atomically $
+      STM.writeTBQueue queue (PlayerConnected color uid connVar)
     incGauge onlineSessions
     $(logTM) InfoS "player connected"
-    pure (sessionVar, uid, connVar)
-  disconnect (sessionVar, uid, _) = do
+    pure (queue, uid, connVar)
+  disconnect (queue, uid, _) = do
     decGauge onlineSessions
     $(logTM) InfoS "player disconnected"
-    disconnectPlayer sessionVar color uid
-    -- Notify the opponent that this player has left
-    MVar.withMVar sessionVar $
-      sendToPlayer (opponent color) (encode OnlineOpponentLeft)
+    STM.atomically $
+      STM.writeTBQueue queue (PlayerDisconnected color uid)
     STM.atomically $ release gameId sessions
-  loop (sessionVar, _, connVar) =
-    runMessageLoop
-      connVar
-      (processEvent sessionVar gameId color)
+  loop (queue, _, connVar) =
+    runMessageLoop connVar $ \clientMsg -> do
+      time <- now
+      STM.atomically $
+        STM.writeTBQueue queue (PlayerMessage color time clientMsg)

--- a/backend/src/Hnefatafl/App/Online.hs
+++ b/backend/src/Hnefatafl/App/Online.hs
@@ -6,6 +6,7 @@ module Hnefatafl.App.Online (
   GameSessions,
   CreateGameResult (..),
   createGame,
+  sweepExpiredTimeouts,
   handleWebSocket,
 
   -- * Internals (exported for testing)
@@ -61,9 +62,11 @@ import Hnefatafl.Core.Data (
   PlayerColor (..),
   RemainingTime,
   TimeControl,
+  deduct,
   opponent,
   remainingToMicroseconds,
   secondsToRemainingTime,
+  toTimespan,
  )
 import Hnefatafl.Core.Data qualified as Data
 import Hnefatafl.Effect.Clock (Clock, delay, now)
@@ -78,9 +81,11 @@ import Hnefatafl.Effect.Storage (
   getOnlineTimeControl,
   getPendingAction,
   insertGame,
+  listExpiredTimeouts,
   runTransaction,
   setOnlineClockState,
   setOnlineTimeControl,
+  setTimeoutAt,
  )
 import Hnefatafl.Effect.Trace (
   Trace,
@@ -108,13 +113,14 @@ import Hnefatafl.Metrics (
   increaseLabelledCounter,
   recordMetrics,
  )
-import Katip (Severity (..))
+import Katip (Severity (..), ls)
 import Network.WebSockets (Connection)
 import OpenTelemetry.Context (lookupSpan)
 import OpenTelemetry.Context.ThreadLocal qualified as ThreadLocal
 import OpenTelemetry.Trace.Core qualified as OT (getSpanContext)
 import Optics ((^.))
 import StmContainers.Map qualified as STMMap
+import Torsor (add, difference)
 
 -------------------------------------------------------------------------------
 -- Types
@@ -272,6 +278,68 @@ createGame timeControl = do
   pure CreateGameResult{game, whiteToken, blackToken}
 
 -------------------------------------------------------------------------------
+-- Sweeper
+
+-- | Resolve timed games that expired without an active session.
+-- Runs periodically to catch games abandoned after server restart
+-- or player disconnect. Uses the timeout_at column written by
+-- handleTimerEvents.
+sweepExpiredTimeouts ::
+  (Storage :> es, Clock :> es, KatipE :> es) =>
+  Eff es ()
+sweepExpiredTimeouts = do
+  currentTime <- now
+  expired <- runTransaction $ listExpiredTimeouts currentTime
+  for_ expired $ \gameId -> do
+    gameState <- runTransaction $ loadOnlineState gameId
+    case gameState.phase of
+      Online.Active{turn} -> do
+        case Online.transition gameState (Online.Timeout turn) of
+          Right (TransitionResult _ events) -> do
+            runTransaction $ do
+              persistEvents gameId currentTime events
+              setTimeoutAt gameId Nothing
+          Left err ->
+            $(logTM) WarningS $
+              ls @Text $
+                "sweeper: transition failed for "
+                  <> show gameId
+                  <> ": "
+                  <> show err
+      _ ->
+        -- Game already finished, clear stale timeout_at
+        runTransaction $ setTimeoutAt gameId Nothing
+
+-- | Create a session and spawn its worker. Returns the event queue.
+createSessionForGame ::
+  ( Storage :> es
+  , Concurrent :> es
+  , IOE :> es
+  , Clock :> es
+  , WebSocket :> es
+  , KatipE :> es
+  , Trace :> es
+  , HMetrics :> es
+  ) =>
+  GameSessions ->
+  GameId ->
+  Online.State ->
+  Eff es (STM.TBQueue SessionEvent)
+createSessionForGame sessions gameId gameState = do
+  -- Arbitrary limit: permissive enough to avoid backpressure
+  -- under normal play, small enough to prevent abuse or
+  -- pathological memory growth.
+  -- Two threads can race into this function for the same game.
+  -- insertOrAcquire is atomic: only one insert wins, the other
+  -- acquires the winner's queue. Only the winner spawns a worker.
+  (queue, inserted) <- STM.atomically $ do
+    q <- STM.newTBQueue 20
+    insertOrAcquire q gameId sessions
+  when inserted $
+    spawnWorker gameId gameState queue
+  pure queue
+
+-------------------------------------------------------------------------------
 -- Session management
 
 -- | Get or create a session's event queue. If a session already
@@ -296,21 +364,7 @@ getOrCreateSession sessions gameId = do
     Just queue -> pure queue
     Nothing -> do
       gameState <- runTransaction $ loadOnlineState gameId
-      -- Arbitrary limit: permissive enough to avoid backpressure
-      -- under normal play, small enough to prevent abuse or
-      -- pathological memory growth.
-      -- Two threads can race past the tryAcquire above if neither
-      -- finds an existing entry. Both load state and create a queue,
-      -- but insertOrAcquire is atomic: only one insert wins, the
-      -- other acquires the winner's queue. The Bool distinguishes
-      -- the winner (who must spawn the worker) from the loser
-      -- (whose queue is discarded by insertOrAcquire).
-      (queue, inserted) <- STM.atomically $ do
-        q <- STM.newTBQueue 20
-        insertOrAcquire q gameId sessions
-      when inserted $
-        spawnWorker gameId gameState queue
-      pure queue
+      createSessionForGame sessions gameId gameState
 
 -------------------------------------------------------------------------------
 -- Session worker
@@ -372,7 +426,9 @@ workerLoop gameId session = do
   let noConnections =
         isNothing session'.whiteConn
           && isNothing session'.blackConn
-      done = isFinished session'.gameState || noConnections
+      done =
+        isFinished session'.gameState
+          || (noConnections && isNothing session'.timeoutAsync)
   if done
     then for_ session'.timeoutAsync Async.cancel
     else workerLoop gameId session'
@@ -426,11 +482,22 @@ dispatchEvent gameId session = \case
     let session' = setConn color (Just (connId, connVar)) session
     safeSend connVar (encode $ gameStateMessage gameId color session'.gameState)
     sendToPlayer (opponent color) (encode OnlineOpponentJoined) session'
-    pure session'
+    -- If reconnecting to a timed game with no active timer,
+    -- check if time has expired and recover the timer.
+    if isNothing session'.timeoutAsync
+      then recoverTimer gameId session'
+      else pure session'
   PlayerDisconnected color connId -> do
     let session' = clearConn color connId session
     sendToPlayer (opponent color) (encode OnlineOpponentLeft) session'
-    pure session'
+    -- Cancel the timer when both players have disconnected. The
+    -- sweeper resolves abandoned games; recoverTimer restarts the
+    -- timer on reconnect.
+    let noConns =
+          isNothing session'.whiteConn && isNothing session'.blackConn
+    if noConns
+      then cancelTimer session'
+      else pure session'
   PlayerMessage color time clientMsg ->
     processGameEvent session gameId color $
       toEvent color time clientMsg
@@ -473,26 +540,43 @@ processGameEvent session gameId color event =
       runTransaction $ persistEvents gameId currentTime events
       sendNotifications color newState events session
       recordMetrics "online" events
-      handleTimerEvents events session{gameState = newState}
+
+      handleTimerEvents gameId events session{gameState = newState}
 
 -------------------------------------------------------------------------------
 -- Timeout timer management
 
--- | Respond to domain events that affect the timer.
+-- | Respond to domain events that affect the timer. Persists the
+-- timeout deadline so the sweeper can resolve abandoned games.
 handleTimerEvents ::
-  (Concurrent :> es, Clock :> es) =>
+  (Storage :> es, Concurrent :> es, Clock :> es) =>
+  GameId ->
   [Common.DomainEvent] ->
   GameSession ->
   Eff es GameSession
-handleTimerEvents events session
-  | any isGameEnded events = cancelTimer session
-  | any isClockUpdated events = resetTimer session
+handleTimerEvents gameId events session
+  | any isGameEnded events = do
+      runTransaction $ setTimeoutAt gameId Nothing
+      cancelTimer session
+  | any isClockUpdated events = do
+      currentTime <- now
+      let deadline = computeDeadline currentTime session.gameState.phase
+      runTransaction $ setTimeoutAt gameId deadline
+      resetTimer session
   | otherwise = pure session
  where
   isGameEnded (Common.GameEnded _) = True
   isGameEnded _ = False
   isClockUpdated (Common.ClockUpdated _) = True
   isClockUpdated _ = False
+
+-- | Compute the absolute deadline for the active player's timeout.
+computeDeadline :: Time -> Online.Phase -> Maybe Time
+computeDeadline currentTime = \case
+  Online.Active{turn, clock = Just (_, cs)} ->
+    let remaining = cs ^. Online.remainingFor turn
+     in Just (add (toTimespan remaining) currentTime)
+  _ -> Nothing
 
 cancelTimer :: Concurrent :> es => GameSession -> Eff es GameSession
 cancelTimer session = do
@@ -510,6 +594,37 @@ resetTimer session = do
       (spawnTimeoutTimer session.eventQueue)
       (activeClockRemaining session.gameState.phase)
   pure session{timeoutAsync = timer}
+
+-- | On reconnect, check if the active player's clock has expired
+-- since turnStartedAt. If expired, apply the timeout transition
+-- directly. If time remains, spawn a timer for the adjusted
+-- duration and persist the deadline for the sweeper.
+recoverTimer ::
+  ( Storage :> es
+  , Clock :> es
+  , Concurrent :> es
+  , WebSocket :> es
+  , KatipE :> es
+  , Trace :> es
+  , HMetrics :> es
+  ) =>
+  GameId ->
+  GameSession ->
+  Eff es GameSession
+recoverTimer gameId session =
+  case session.gameState.phase of
+    Online.Active{turn, clock = Just (_, cs)} -> do
+      currentTime <- now
+      let elapsed = difference currentTime cs.turnStartedAt
+      case deduct elapsed (cs ^. Online.remainingFor turn) of
+        Nothing ->
+          processGameEvent session gameId turn (Online.Timeout turn)
+        Just adjusted -> do
+          let deadline = add (toTimespan adjusted) currentTime
+          runTransaction $ setTimeoutAt gameId (Just deadline)
+          timer <- spawnTimeoutTimer session.eventQueue (turn, adjusted)
+          pure session{timeoutAsync = Just timer}
+    _ -> pure session
 
 -- | Extract the active player's remaining time from the game phase.
 -- Returns Nothing if the game is finished or has no clock.

--- a/backend/src/Hnefatafl/App/Online.hs
+++ b/backend/src/Hnefatafl/App/Online.hs
@@ -60,16 +60,14 @@ import Hnefatafl.Core.Data (
   GameParticipantToken (..),
   GameParticipantTokenId (..),
   PlayerColor (..),
-  RemainingTime,
   TimeControl,
   deduct,
   opponent,
-  remainingToMicroseconds,
   secondsToRemainingTime,
   toTimespan,
  )
 import Hnefatafl.Core.Data qualified as Data
-import Hnefatafl.Effect.Clock (Clock, delay, now)
+import Hnefatafl.Effect.Clock (Clock, delayUntil, now)
 import Hnefatafl.Effect.IdGen (IdGen, generateId)
 import Hnefatafl.Effect.Storage (
   Storage,
@@ -502,8 +500,17 @@ dispatchEvent gameId session = \case
     processGameEvent session gameId color $
       toEvent color time clientMsg
   TimeoutFired color ->
-    processGameEvent session gameId color $
-      Online.Timeout color
+    -- A timer can enqueue a TimeoutFired in the window between a move
+    -- switching the turn and resetTimer cancelling that timer;
+    -- Async.cancel cannot un-enqueue an already-written event. Drop a
+    -- timeout for a player who is no longer to move (or a game that has
+    -- ended) rather than routing it through the transition, which would
+    -- reject it and surface a spurious error to that client.
+    case session.gameState.phase of
+      Online.Active{turn}
+        | turn == color ->
+            processGameEvent session gameId color (Online.Timeout color)
+      _ -> pure session
 
 -------------------------------------------------------------------------------
 -- Game event processing
@@ -561,8 +568,8 @@ handleTimerEvents gameId events session
   | any isClockUpdated events = do
       currentTime <- now
       let deadline = computeDeadline currentTime session.gameState.phase
-      runTransaction $ setTimeoutAt gameId deadline
-      resetTimer session
+      runTransaction $ setTimeoutAt gameId (snd <$> deadline)
+      resetTimer deadline session
   | otherwise = pure session
  where
   isGameEnded (Common.GameEnded _) = True
@@ -570,12 +577,13 @@ handleTimerEvents gameId events session
   isClockUpdated (Common.ClockUpdated _) = True
   isClockUpdated _ = False
 
--- | Compute the absolute deadline for the active player's timeout.
-computeDeadline :: Time -> Online.Phase -> Maybe Time
+-- | Compute the active player and the absolute deadline at which
+-- their clock expires. Nothing when the game is finished or untimed.
+computeDeadline :: Time -> Online.Phase -> Maybe (PlayerColor, Time)
 computeDeadline currentTime = \case
   Online.Active{turn, clock = Just (_, cs)} ->
     let remaining = cs ^. Online.remainingFor turn
-     in Just (add (toTimespan remaining) currentTime)
+     in Just (turn, add (toTimespan remaining) currentTime)
   _ -> Nothing
 
 cancelTimer :: Concurrent :> es => GameSession -> Eff es GameSession
@@ -585,14 +593,12 @@ cancelTimer session = do
 
 resetTimer ::
   (Concurrent :> es, Clock :> es) =>
+  Maybe (PlayerColor, Time) ->
   GameSession ->
   Eff es GameSession
-resetTimer session = do
+resetTimer deadline session = do
   for_ session.timeoutAsync Async.cancel
-  timer <-
-    traverse
-      (spawnTimeoutTimer session.eventQueue)
-      (activeClockRemaining session.gameState.phase)
+  timer <- traverse (spawnTimeoutTimer session.eventQueue) deadline
   pure session{timeoutAsync = timer}
 
 -- | On reconnect, check if the active player's clock has expired
@@ -622,28 +628,21 @@ recoverTimer gameId session =
         Just adjusted -> do
           let deadline = add (toTimespan adjusted) currentTime
           runTransaction $ setTimeoutAt gameId (Just deadline)
-          timer <- spawnTimeoutTimer session.eventQueue (turn, adjusted)
+          timer <- spawnTimeoutTimer session.eventQueue (turn, deadline)
           pure session{timeoutAsync = Just timer}
     _ -> pure session
 
--- | Extract the active player's remaining time from the game phase.
--- Returns Nothing if the game is finished or has no clock.
-activeClockRemaining :: Online.Phase -> Maybe (PlayerColor, RemainingTime)
-activeClockRemaining = \case
-  Online.Active{turn, clock = Just (_, cs)} ->
-    Just (turn, cs ^. Online.remainingFor turn)
-  _ -> Nothing
-
--- | Spawn an async that sleeps for the given remaining time, then
--- enqueues a TimeoutFired event.
+-- | Spawn an async that sleeps until the given absolute deadline,
+-- then enqueues a TimeoutFired event. The deadline is captured by
+-- the caller so it cannot drift with the spawned thread's start.
 spawnTimeoutTimer ::
   (Concurrent :> es, Clock :> es) =>
   STM.TBQueue SessionEvent ->
-  (PlayerColor, RemainingTime) ->
+  (PlayerColor, Time) ->
   Eff es (Async.Async ())
-spawnTimeoutTimer queue (color, remaining) =
+spawnTimeoutTimer queue (color, deadline) =
   Async.async $ do
-    delay $ remainingToMicroseconds remaining
+    delayUntil deadline
     STM.atomically $ STM.writeTBQueue queue $ TimeoutFired color
 
 -------------------------------------------------------------------------------

--- a/backend/src/Hnefatafl/App/Online.hs
+++ b/backend/src/Hnefatafl/App/Online.hs
@@ -619,17 +619,21 @@ recoverTimer ::
   Eff es GameSession
 recoverTimer gameId session =
   case session.gameState.phase of
-    Online.Active{turn, clock = Just (_, cs)} -> do
-      currentTime <- now
-      let elapsed = difference currentTime cs.turnStartedAt
-      case deduct elapsed (cs ^. Online.remainingFor turn) of
-        Nothing ->
-          processGameEvent session gameId turn (Online.Timeout turn)
-        Just adjusted -> do
-          let deadline = add (toTimespan adjusted) currentTime
-          runTransaction $ setTimeoutAt gameId (Just deadline)
-          timer <- spawnTimeoutTimer session.eventQueue (turn, deadline)
-          pure session{timeoutAsync = Just timer}
+    Online.Active{turn, clock = Just (_, cs)}
+      -- The clock only starts once the first move is played, so a
+      -- game with no moves has no timeout to recover. Arming one here
+      -- would let the first mover flag before their free opening move.
+      | not (null session.gameState.moves) -> do
+          currentTime <- now
+          let elapsed = difference currentTime cs.turnStartedAt
+          case deduct elapsed (cs ^. Online.remainingFor turn) of
+            Nothing ->
+              processGameEvent session gameId turn (Online.Timeout turn)
+            Just adjusted -> do
+              let deadline = add (toTimespan adjusted) currentTime
+              runTransaction $ setTimeoutAt gameId (Just deadline)
+              timer <- spawnTimeoutTimer session.eventQueue (turn, deadline)
+              pure session{timeoutAsync = Just timer}
     _ -> pure session
 
 -- | Spawn an async that sleeps until the given absolute deadline,

--- a/backend/src/Hnefatafl/App/Online.hs
+++ b/backend/src/Hnefatafl/App/Online.hs
@@ -59,12 +59,14 @@ import Hnefatafl.Core.Data (
   GameParticipantToken (..),
   GameParticipantTokenId (..),
   PlayerColor (..),
+  RemainingTime,
   TimeControl,
   opponent,
+  remainingToMicroseconds,
   secondsToRemainingTime,
  )
 import Hnefatafl.Core.Data qualified as Data
-import Hnefatafl.Effect.Clock (Clock, now)
+import Hnefatafl.Effect.Clock (Clock, delay, now)
 import Hnefatafl.Effect.IdGen (IdGen, generateId)
 import Hnefatafl.Effect.Storage (
   Storage,
@@ -111,6 +113,7 @@ import Network.WebSockets (Connection)
 import OpenTelemetry.Context (lookupSpan)
 import OpenTelemetry.Context.ThreadLocal qualified as ThreadLocal
 import OpenTelemetry.Trace.Core qualified as OT (getSpanContext)
+import Optics ((^.))
 import StmContainers.Map qualified as STMMap
 
 -------------------------------------------------------------------------------
@@ -126,15 +129,18 @@ data SessionEvent
   = PlayerMessage PlayerColor Time OnlineClientMessage
   | PlayerConnected PlayerColor ConnectionId (MVar Connection)
   | PlayerDisconnected PlayerColor ConnectionId
+  | TimeoutFired PlayerColor
 
 -- | In-memory session for an active online game. A session exists
 -- while at least one player is connected; the underlying game
 -- persists in the database across sessions. Owned exclusively by the
 -- worker loop, must never be shared.
 data GameSession = GameSession
-  { gameState :: Online.State
+  { eventQueue :: STM.TBQueue SessionEvent
+  , gameState :: Online.State
   , whiteConn :: Maybe (ConnectionId, MVar Connection)
   , blackConn :: Maybe (ConnectionId, MVar Connection)
+  , timeoutAsync :: Maybe (Async.Async ())
   }
   deriving (Generic)
 
@@ -164,6 +170,7 @@ eventColor :: SessionEvent -> PlayerColor
 eventColor (PlayerMessage c _ _) = c
 eventColor (PlayerConnected c _ _) = c
 eventColor (PlayerDisconnected c _) = c
+eventColor (TimeoutFired c) = c
 
 isFinished :: Online.State -> Bool
 isFinished (Online.State _ _ (Online.Finished _)) = True
@@ -340,10 +347,10 @@ spawnWorker gameId initialState queue = do
           case mSpanCtx of
             Just spanCtx ->
               inSpanWithLink "online.session" spanCtx $
-                workerLoop gameId queue (GameSession initialState Nothing Nothing)
+                workerLoop gameId (GameSession queue initialState Nothing Nothing Nothing)
             Nothing ->
               inSpan "online.session" $
-                workerLoop gameId queue (GameSession initialState Nothing Nothing)
+                workerLoop gameId (GameSession queue initialState Nothing Nothing Nothing)
 
 -- | Process events from the queue until the game is finished and
 -- both players have disconnected.
@@ -357,18 +364,18 @@ workerLoop ::
   , HMetrics :> es
   ) =>
   GameId ->
-  STM.TBQueue SessionEvent ->
   GameSession ->
   Eff es ()
-workerLoop gameId queue session = do
-  event <- STM.atomically $ STM.readTBQueue queue
+workerLoop gameId session = do
+  event <- STM.atomically $ STM.readTBQueue session.eventQueue
   session' <- handleSessionEvent gameId session event
   let noConnections =
         isNothing session'.whiteConn
           && isNothing session'.blackConn
       done = isFinished session'.gameState || noConnections
-  unless done $
-    workerLoop gameId queue session'
+  if done
+    then for_ session'.timeoutAsync Async.cancel
+    else workerLoop gameId session'
 
 -- | Dispatch a session event. Non-fatal domain exceptions are
 -- absorbed (logged + reported to the acting player) so the worker
@@ -425,13 +432,18 @@ dispatchEvent gameId session = \case
     sendToPlayer (opponent color) (encode OnlineOpponentLeft) session'
     pure session'
   PlayerMessage color time clientMsg ->
-    processGameEvent session gameId color time clientMsg
+    processGameEvent session gameId color $
+      toEvent color time clientMsg
+  TimeoutFired color ->
+    processGameEvent session gameId color $
+      Online.Timeout color
 
 -------------------------------------------------------------------------------
 -- Game event processing
 
--- | Process a game event from a player. Transitions state, persists
--- to DB, sends notifications, and records metrics. Not thread-safe.
+-- | Process a domain game event. Transitions state, persists to DB,
+-- sends notifications, records metrics, and manages the timeout
+-- timer. Not thread-safe.
 processGameEvent ::
   ( Storage :> es
   , Clock :> es
@@ -444,11 +456,9 @@ processGameEvent ::
   GameSession ->
   GameId ->
   PlayerColor ->
-  Time ->
-  OnlineClientMessage ->
+  Online.Event ->
   Eff es GameSession
-processGameEvent session gameId color currentTime clientMsg = do
-  let event = toEvent color currentTime clientMsg
+processGameEvent session gameId color event =
   case Online.transition session.gameState event of
     Left err -> do
       when (err == Common.InvalidMove) $
@@ -459,10 +469,70 @@ processGameEvent session gameId color currentTime clientMsg = do
         session
       pure session
     Right (TransitionResult newState events) -> do
+      currentTime <- now
       runTransaction $ persistEvents gameId currentTime events
       sendNotifications color newState events session
       recordMetrics "online" events
-      pure session{gameState = newState}
+      handleTimerEvents events session{gameState = newState}
+
+-------------------------------------------------------------------------------
+-- Timeout timer management
+
+-- | Respond to domain events that affect the timer.
+handleTimerEvents ::
+  (Concurrent :> es, Clock :> es) =>
+  [Common.DomainEvent] ->
+  GameSession ->
+  Eff es GameSession
+handleTimerEvents events session
+  | any isGameEnded events = cancelTimer session
+  | any isClockUpdated events = resetTimer session
+  | otherwise = pure session
+ where
+  isGameEnded (Common.GameEnded _) = True
+  isGameEnded _ = False
+  isClockUpdated (Common.ClockUpdated _) = True
+  isClockUpdated _ = False
+
+cancelTimer :: Concurrent :> es => GameSession -> Eff es GameSession
+cancelTimer session = do
+  for_ session.timeoutAsync Async.cancel
+  pure session{timeoutAsync = Nothing}
+
+resetTimer ::
+  (Concurrent :> es, Clock :> es) =>
+  GameSession ->
+  Eff es GameSession
+resetTimer session = do
+  for_ session.timeoutAsync Async.cancel
+  timer <-
+    traverse
+      (spawnTimeoutTimer session.eventQueue)
+      (activeClockRemaining session.gameState.phase)
+  pure session{timeoutAsync = timer}
+
+-- | Extract the active player's remaining time from the game phase.
+-- Returns Nothing if the game is finished or has no clock.
+activeClockRemaining :: Online.Phase -> Maybe (PlayerColor, RemainingTime)
+activeClockRemaining = \case
+  Online.Active{turn, clock = Just (_, cs)} ->
+    Just (turn, cs ^. Online.remainingFor turn)
+  _ -> Nothing
+
+-- | Spawn an async that sleeps for the given remaining time, then
+-- enqueues a TimeoutFired event.
+spawnTimeoutTimer ::
+  (Concurrent :> es, Clock :> es) =>
+  STM.TBQueue SessionEvent ->
+  (PlayerColor, RemainingTime) ->
+  Eff es (Async.Async ())
+spawnTimeoutTimer queue (color, remaining) =
+  Async.async $ do
+    delay $ remainingToMicroseconds remaining
+    STM.atomically $ STM.writeTBQueue queue $ TimeoutFired color
+
+-------------------------------------------------------------------------------
+-- Notifications
 
 -- | Send all notifications derived from domain events to the
 -- appropriate players.

--- a/backend/src/Hnefatafl/App/Online.hs
+++ b/backend/src/Hnefatafl/App/Online.hs
@@ -177,7 +177,7 @@ eventColor (PlayerDisconnected c _) = c
 eventColor (TimeoutFired c) = c
 
 isFinished :: Online.State -> Bool
-isFinished (Online.State _ _ (Online.Finished _)) = True
+isFinished (Online.State _ _ (Online.Finished _) _) = True
 isFinished _ = False
 
 -------------------------------------------------------------------------------
@@ -210,7 +210,9 @@ loadOnlineState gameId = do
   clockState <- getOnlineClockState gameId
   let appliedMoves = gameMoveToAppliedMoves gameMoves
       board = currentBoard appliedMoves
-      clock = liftA2 (,) timeControl clockState
+      clock = case (timeControl, clockState) of
+        (Just tc, Just cs) -> Online.Timed tc cs
+        _ -> Online.Untimed
   pure $
     Online.reconstruct
       board
@@ -567,7 +569,7 @@ handleTimerEvents gameId events session
       cancelTimer session
   | any isClockUpdated events = do
       currentTime <- now
-      let deadline = computeDeadline currentTime session.gameState.phase
+      let deadline = computeDeadline currentTime session.gameState
       runTransaction $ setTimeoutAt gameId (snd <$> deadline)
       resetTimer deadline session
   | otherwise = pure session
@@ -579,9 +581,9 @@ handleTimerEvents gameId events session
 
 -- | Compute the active player and the absolute deadline at which
 -- their clock expires. Nothing when the game is finished or untimed.
-computeDeadline :: Time -> Online.Phase -> Maybe (PlayerColor, Time)
+computeDeadline :: Time -> Online.State -> Maybe (PlayerColor, Time)
 computeDeadline currentTime = \case
-  Online.Active{turn, clock = Just (_, cs)} ->
+  Online.State _ _ Online.Active{turn} (Online.Timed _ cs) ->
     let remaining = cs ^. Online.remainingFor turn
      in Just (turn, add (toTimespan remaining) currentTime)
   _ -> Nothing
@@ -618,12 +620,12 @@ recoverTimer ::
   GameSession ->
   Eff es GameSession
 recoverTimer gameId session =
-  case session.gameState.phase of
-    Online.Active{turn, clock = Just (_, cs)}
+  case session.gameState of
+    Online.State _ moves Online.Active{turn} (Online.Timed _ cs)
       -- The clock only starts once the first move is played, so a
       -- game with no moves has no timeout to recover. Arming one here
       -- would let the first mover flag before their free opening move.
-      | not (null session.gameState.moves) -> do
+      | not (null moves) -> do
           currentTime <- now
           let elapsed = difference currentTime cs.turnStartedAt
           case deduct elapsed (cs ^. Online.remainingFor turn) of

--- a/backend/src/Hnefatafl/App/Online.hs
+++ b/backend/src/Hnefatafl/App/Online.hs
@@ -51,6 +51,7 @@ import Hnefatafl.App.WebSocket (
   withGameContext,
  )
 import Hnefatafl.Core.Data (
+  ClockState (..),
   Game (..),
   GameId (..),
   GameMode (..),
@@ -59,6 +60,7 @@ import Hnefatafl.Core.Data (
   PlayerColor (..),
   TimeControl,
   opponent,
+  secondsToRemainingTime,
  )
 import Hnefatafl.Core.Data qualified as Data
 import Hnefatafl.Effect.Clock (Clock, now)
@@ -69,9 +71,12 @@ import Hnefatafl.Effect.Storage (
   createGameParticipantToken,
   getGame,
   getMovesForGame,
+  getOnlineClockState,
+  getOnlineTimeControl,
   getPendingAction,
   insertGame,
   runTransaction,
+  setOnlineClockState,
   setOnlineTimeControl,
  )
 import Hnefatafl.Effect.Trace (Trace)
@@ -147,7 +152,7 @@ toEvent color time = \case
   OnlineAcceptDraw -> Online.AcceptDraw color
   OnlineDeclineDraw -> Online.DeclineDraw color
   OnlineRequestUndo -> Online.RequestUndo color
-  OnlineAcceptUndo -> Online.AcceptUndo color
+  OnlineAcceptUndo -> Online.AcceptUndo color time
   OnlineDeclineUndo -> Online.DeclineUndo color
 
 -------------------------------------------------------------------------------
@@ -159,14 +164,18 @@ loadOnlineState gameId = do
   game <- getGame gameId
   gameMoves <- getMovesForGame gameId
   pendingAction <- getPendingAction gameId
+  timeControl <- getOnlineTimeControl gameId
+  clockState <- getOnlineClockState gameId
   let appliedMoves = gameMoveToAppliedMoves gameMoves
       board = currentBoard appliedMoves
+      clock = liftA2 (,) timeControl clockState
   pure $
     Online.reconstruct
       board
       appliedMoves
       game.outcome
       pendingAction
+      clock
 
 mkGame :: GameId -> Time -> Game
 mkGame gameId time =
@@ -216,7 +225,11 @@ createGame timeControl = do
     insertGame game
     createGameParticipantToken whiteToken
     createGameParticipantToken blackToken
-    for_ timeControl $ setOnlineTimeControl game.gameId
+    for_ timeControl $ \tc -> do
+      setOnlineTimeControl game.gameId tc
+      let initial = secondsToRemainingTime tc.initialTime
+      setOnlineClockState game.gameId $
+        ClockState initial initial game.startTime
   increaseLabelledCounter gamesCreated "online"
   pure CreateGameResult{game, whiteToken, blackToken}
 

--- a/backend/src/Hnefatafl/App/Online/Serialization.hs
+++ b/backend/src/Hnefatafl/App/Online/Serialization.hs
@@ -32,7 +32,10 @@ import Hnefatafl.Game.Online qualified as Online
 
 -- | Derive notifications from domain events. Returns (target, message) pairs.
 notificationsFor ::
-  PlayerColor -> Online.State -> [DomainEvent] -> [(PlayerColor, OnlineServerMessage)]
+  PlayerColor ->
+  Online.State ->
+  [DomainEvent] ->
+  [(PlayerColor, OnlineServerMessage)]
 notificationsFor actor newState = concatMap $ \case
   MovePlayed am ->
     [(opponent actor, opponentMovedMsg am)]
@@ -56,6 +59,8 @@ notificationsFor actor newState = concatMap $ \case
     [(offerer, OnlineDrawCancelled)]
   OfferAutoCancelled UndoRequest offerer ->
     [(offerer, OnlineUndoCancelled)]
+  ClockUpdated _ ->
+    []
  where
   opponentMovedMsg am =
     let (turn', status', validMoves', board') = activeStateFields newState
@@ -84,7 +89,10 @@ gameStateMessage gId playerColor (Online.State board moves phase) =
     { _gameId = gId
     , _playerColor = playerColor
     , _board = boardFromExtern board
-    , _history = map (\am -> historyEntryFromDomain (MoveWithCaptures am.move am.captures) am.side) moves
+    , _history =
+        map
+          (\am -> historyEntryFromDomain (MoveWithCaptures am.move am.captures) am.side)
+          moves
     , _turn = turn'
     , _status = status'
     , _validMoves = validMoves'
@@ -92,7 +100,7 @@ gameStateMessage gId playerColor (Online.State board moves phase) =
     }
  where
   (turn', status', validMoves', pending') = case phase of
-    Online.Active turn validMoves pending ->
+    Online.Active{turn, validMoves, pending} ->
       ( turn
       , gameStatusFromDomain Nothing
       , validMovesMapFromDomain validMoves
@@ -106,10 +114,11 @@ gameStateMessage gId playerColor (Online.State board moves phase) =
       )
 
 -- | Extract common state fields from an Online state.
-activeStateFields :: Online.State -> (PlayerColor, ApiGameStatus, ValidMovesMap, ApiBoard)
+activeStateFields ::
+  Online.State -> (PlayerColor, ApiGameStatus, ValidMovesMap, ApiBoard)
 activeStateFields (Online.State board _moves phase) =
   case phase of
-    Online.Active turn validMoves _pending ->
+    Online.Active{turn, validMoves} ->
       ( turn
       , gameStatusFromDomain Nothing
       , validMovesMapFromDomain validMoves

--- a/backend/src/Hnefatafl/App/Online/Serialization.hs
+++ b/backend/src/Hnefatafl/App/Online/Serialization.hs
@@ -18,7 +18,7 @@ import Hnefatafl.Api.Types (
 import Hnefatafl.Api.Types.WS (
   pendingActionFromDomain,
  )
-import Hnefatafl.Api.Types.WS.Online (OnlineServerMessage (..))
+import Hnefatafl.Api.Types.WS.Online (ClockMs (..), OnlineServerMessage (..))
 import Hnefatafl.Core.Data (
   ClockState (..),
   GameId,
@@ -49,8 +49,7 @@ notificationsFor actor newState = concatMap $ \case
     let msg =
           OnlineGameOver
             { _status = gameStatusFromDomain (Just outcome)
-            , _whiteRemainingMs = whiteMs
-            , _blackRemainingMs = blackMs
+            , _clock = clockMs
             }
      in [(opponent actor, msg), (actor, msg)]
   MovesUndone n ->
@@ -80,7 +79,7 @@ notificationsFor actor newState = concatMap $ \case
       )
     ]
  where
-  (whiteMs, blackMs) = clockMsFields newState
+  clockMs = clockMsFields newState
   opponentMovedMsg am =
     let (turn', status', validMoves', board') = activeStateFields newState
      in OnlineMoveMade
@@ -90,8 +89,7 @@ notificationsFor actor newState = concatMap $ \case
           , _status = status'
           , _validMoves = validMoves'
           , _board = board'
-          , _whiteRemainingMs = whiteMs
-          , _blackRemainingMs = blackMs
+          , _clock = clockMs
           }
   undoMsg n =
     let (turn', status', validMoves', board') = activeStateFields newState
@@ -101,8 +99,7 @@ notificationsFor actor newState = concatMap $ \case
           , _status = status'
           , _validMoves = validMoves'
           , _board = board'
-          , _whiteRemainingMs = whiteMs
-          , _blackRemainingMs = blackMs
+          , _clock = clockMs
           }
 
 -- | Serialize the full game state for initial sync on connect.
@@ -120,11 +117,10 @@ gameStateMessage gId playerColor s@(Online.State board moves phase) =
     , _status = status'
     , _validMoves = validMoves'
     , _pendingAction = pending'
-    , _whiteRemainingMs = whiteMs
-    , _blackRemainingMs = blackMs
+    , _clock = clockMs
     }
  where
-  (whiteMs, blackMs) = clockMsFields s
+  clockMs = clockMsFields s
   (turn', status', validMoves', pending') = case phase of
     Online.Active{turn, validMoves, pending} ->
       ( turn
@@ -158,13 +154,14 @@ activeStateFields (Online.State board _moves phase) =
       )
 
 -- | Extract clock millisecond values from game state.
-clockMsFields :: Online.State -> (Maybe Int, Maybe Int)
+clockMsFields :: Online.State -> Maybe ClockMs
 clockMsFields (Online.State _ _ phase) = case phase of
   Online.Active{clock = Just (_, cs)} ->
-    ( Just (remainingToMs cs.whiteRemaining)
-    , Just (remainingToMs cs.blackRemaining)
-    )
-  _ -> (Nothing, Nothing)
+    Just $
+      ClockMs
+        (remainingToMs cs.whiteRemaining)
+        (remainingToMs cs.blackRemaining)
+  _ -> Nothing
 
 -- | Converts nanosecond-precision remaining time to whole milliseconds
 -- for the wire format, which uses integer milliseconds to avoid

--- a/backend/src/Hnefatafl/App/Online/Serialization.hs
+++ b/backend/src/Hnefatafl/App/Online/Serialization.hs
@@ -24,6 +24,7 @@ import Hnefatafl.Core.Data (
   PlayerColor (..),
   opponent,
   remainingToMs,
+  timeToMs,
  )
 import Hnefatafl.Game.Common (
   AppliedMove (..),
@@ -71,6 +72,7 @@ notificationsFor actor newState = concatMap $ \case
       , OnlineClockUpdated
           { _whiteMs = remainingToMs cs.whiteRemaining
           , _blackMs = remainingToMs cs.blackRemaining
+          , _turnStartedAtMs = timeToMs cs.turnStartedAt
           }
       )
     ]
@@ -157,4 +159,5 @@ clockMsFields (Online.State _ _ phase) = case phase of
       ClockMs
         (remainingToMs cs.whiteRemaining)
         (remainingToMs cs.blackRemaining)
+        (timeToMs cs.turnStartedAt)
   _ -> Nothing

--- a/backend/src/Hnefatafl/App/Online/Serialization.hs
+++ b/backend/src/Hnefatafl/App/Online/Serialization.hs
@@ -102,7 +102,7 @@ notificationsFor actor newState = concatMap $ \case
 
 -- | Serialize the full game state for initial sync on connect.
 gameStateMessage :: GameId -> PlayerColor -> Online.State -> OnlineServerMessage
-gameStateMessage gId playerColor s@(Online.State board moves phase) =
+gameStateMessage gId playerColor s@(Online.State board moves phase _) =
   OnlineGameState
     { _gameId = gId
     , _playerColor = playerColor
@@ -136,7 +136,7 @@ gameStateMessage gId playerColor s@(Online.State board moves phase) =
 -- | Extract common state fields from an Online state.
 activeStateFields ::
   Online.State -> (PlayerColor, ApiGameStatus, ValidMovesMap, ApiBoard)
-activeStateFields (Online.State board _moves phase) =
+activeStateFields (Online.State board _moves phase _) =
   case phase of
     Online.Active{turn, validMoves} ->
       ( turn
@@ -151,10 +151,12 @@ activeStateFields (Online.State board _moves phase) =
       , boardFromExtern board
       )
 
--- | Extract clock millisecond values from game state.
+-- | Extract clock millisecond values from game state. Only an active
+-- timed game reports a clock; a finished game reports none even though
+-- its configuration survives on the state.
 clockMsFields :: Online.State -> Maybe ClockMs
-clockMsFields (Online.State _ _ phase) = case phase of
-  Online.Active{clock = Just (_, cs)} ->
+clockMsFields (Online.State _ _ phase clock) = case (phase, clock) of
+  (Online.Active{}, Online.Timed _ cs) ->
     Just $
       ClockMs
         (remainingToMs cs.whiteRemaining)

--- a/backend/src/Hnefatafl/App/Online/Serialization.hs
+++ b/backend/src/Hnefatafl/App/Online/Serialization.hs
@@ -1,8 +1,10 @@
 module Hnefatafl.App.Online.Serialization (
   notificationsFor,
   gameStateMessage,
+  remainingToMs,
 ) where
 
+import Chronos (getTimespan)
 import Hnefatafl.Api.Types (
   ApiBoard,
   ApiGameStatus,
@@ -18,10 +20,14 @@ import Hnefatafl.Api.Types.WS (
  )
 import Hnefatafl.Api.Types.WS.Online (OnlineServerMessage (..))
 import Hnefatafl.Core.Data (
+  ClockState (..),
   GameId,
   MoveWithCaptures (..),
   PlayerColor (..),
+  RemainingTime,
+  nanosPerMillisecond,
   opponent,
+  toTimespan,
  )
 import Hnefatafl.Game.Common (
   AppliedMove (..),
@@ -40,7 +46,12 @@ notificationsFor actor newState = concatMap $ \case
   MovePlayed am ->
     [(opponent actor, opponentMovedMsg am)]
   GameEnded outcome ->
-    let msg = OnlineGameOver{_status = gameStatusFromDomain (Just outcome)}
+    let msg =
+          OnlineGameOver
+            { _status = gameStatusFromDomain (Just outcome)
+            , _whiteRemainingMs = whiteMs
+            , _blackRemainingMs = blackMs
+            }
      in [(opponent actor, msg), (actor, msg)]
   MovesUndone n ->
     let msg = undoMsg n
@@ -59,9 +70,17 @@ notificationsFor actor newState = concatMap $ \case
     [(offerer, OnlineDrawCancelled)]
   OfferAutoCancelled UndoRequest offerer ->
     [(offerer, OnlineUndoCancelled)]
-  ClockUpdated _ ->
-    []
+  ClockUpdated cs ->
+    [
+      ( actor
+      , OnlineClockUpdated
+          { _whiteMs = remainingToMs cs.whiteRemaining
+          , _blackMs = remainingToMs cs.blackRemaining
+          }
+      )
+    ]
  where
+  (whiteMs, blackMs) = clockMsFields newState
   opponentMovedMsg am =
     let (turn', status', validMoves', board') = activeStateFields newState
      in OnlineMoveMade
@@ -71,6 +90,8 @@ notificationsFor actor newState = concatMap $ \case
           , _status = status'
           , _validMoves = validMoves'
           , _board = board'
+          , _whiteRemainingMs = whiteMs
+          , _blackRemainingMs = blackMs
           }
   undoMsg n =
     let (turn', status', validMoves', board') = activeStateFields newState
@@ -80,11 +101,13 @@ notificationsFor actor newState = concatMap $ \case
           , _status = status'
           , _validMoves = validMoves'
           , _board = board'
+          , _whiteRemainingMs = whiteMs
+          , _blackRemainingMs = blackMs
           }
 
 -- | Serialize the full game state for initial sync on connect.
 gameStateMessage :: GameId -> PlayerColor -> Online.State -> OnlineServerMessage
-gameStateMessage gId playerColor (Online.State board moves phase) =
+gameStateMessage gId playerColor s@(Online.State board moves phase) =
   OnlineGameState
     { _gameId = gId
     , _playerColor = playerColor
@@ -97,8 +120,11 @@ gameStateMessage gId playerColor (Online.State board moves phase) =
     , _status = status'
     , _validMoves = validMoves'
     , _pendingAction = pending'
+    , _whiteRemainingMs = whiteMs
+    , _blackRemainingMs = blackMs
     }
  where
+  (whiteMs, blackMs) = clockMsFields s
   (turn', status', validMoves', pending') = case phase of
     Online.Active{turn, validMoves, pending} ->
       ( turn
@@ -107,7 +133,7 @@ gameStateMessage gId playerColor (Online.State board moves phase) =
       , fmap pendingActionFromDomain pending
       )
     Online.Finished outcome ->
-      ( Black
+      ( Black -- Turn is meaningless post-game; placeholder value.
       , gameStatusFromDomain (Just outcome)
       , validMovesMapFromDomain []
       , Nothing
@@ -125,8 +151,23 @@ activeStateFields (Online.State board _moves phase) =
       , boardFromExtern board
       )
     Online.Finished outcome ->
-      ( Black
+      ( Black -- Turn is meaningless post-game; placeholder value.
       , gameStatusFromDomain (Just outcome)
       , validMovesMapFromDomain []
       , boardFromExtern board
       )
+
+-- | Extract clock millisecond values from game state.
+clockMsFields :: Online.State -> (Maybe Int, Maybe Int)
+clockMsFields (Online.State _ _ phase) = case phase of
+  Online.Active{clock = Just (_, cs)} ->
+    ( Just (remainingToMs cs.whiteRemaining)
+    , Just (remainingToMs cs.blackRemaining)
+    )
+  _ -> (Nothing, Nothing)
+
+-- | Converts nanosecond-precision remaining time to whole milliseconds
+-- for the wire format, which uses integer milliseconds to avoid
+-- floating-point precision issues on clients.
+remainingToMs :: RemainingTime -> Int
+remainingToMs rt = fromIntegral (getTimespan (toTimespan rt) `div` nanosPerMillisecond)

--- a/backend/src/Hnefatafl/App/Online/Serialization.hs
+++ b/backend/src/Hnefatafl/App/Online/Serialization.hs
@@ -1,10 +1,8 @@
 module Hnefatafl.App.Online.Serialization (
   notificationsFor,
   gameStateMessage,
-  remainingToMs,
 ) where
 
-import Chronos (getTimespan)
 import Hnefatafl.Api.Types (
   ApiBoard,
   ApiGameStatus,
@@ -24,10 +22,8 @@ import Hnefatafl.Core.Data (
   GameId,
   MoveWithCaptures (..),
   PlayerColor (..),
-  RemainingTime,
-  nanosPerMillisecond,
   opponent,
-  toTimespan,
+  remainingToMs,
  )
 import Hnefatafl.Game.Common (
   AppliedMove (..),
@@ -162,9 +158,3 @@ clockMsFields (Online.State _ _ phase) = case phase of
         (remainingToMs cs.whiteRemaining)
         (remainingToMs cs.blackRemaining)
   _ -> Nothing
-
--- | Converts nanosecond-precision remaining time to whole milliseconds
--- for the wire format, which uses integer milliseconds to avoid
--- floating-point precision issues on clients.
-remainingToMs :: RemainingTime -> Int
-remainingToMs rt = fromIntegral (getTimespan (toTimespan rt) `div` nanosPerMillisecond)

--- a/backend/src/Hnefatafl/App/Session.hs
+++ b/backend/src/Hnefatafl/App/Session.hs
@@ -10,23 +10,24 @@ module Hnefatafl.App.Session (
 import Focus qualified
 import StmContainers.Map qualified as STMMap
 
--- | A session entry in the map, pairing the session MVar with a reference
--- count. The refcount tracks how many active WebSocket handler threads
--- hold a reference, ensuring the entry is only deleted when all handlers
--- have exited. This prevents a race where a disconnecting handler deletes
--- the entry while a reconnecting handler has already looked it up.
+-- | A session entry in the map, pairing a session handle with a
+-- reference count. The refcount tracks how many active WebSocket
+-- handler threads hold a reference, ensuring the entry is only
+-- deleted when all handlers have exited. The session value is
+-- opaque — each consumer chooses its own type (e.g. MVar for
+-- AI, TBQueue for Online).
 data SessionEntry a = SessionEntry
-  { session :: MVar a
+  { session :: a
   , refCount :: TVar Int
   }
 
--- | Try to acquire an existing session. Atomically increments the refcount
--- if found, returns Nothing if no session exists for this key.
+-- | Try to acquire an existing session. Atomically increments the
+-- refcount if found, returns Nothing if no session exists.
 tryAcquire ::
   Hashable key =>
   key ->
   STMMap.Map key (SessionEntry a) ->
-  STM (Maybe (MVar a))
+  STM (Maybe a)
 tryAcquire =
   STMMap.focus $
     Focus.casesM
@@ -35,25 +36,25 @@ tryAcquire =
         modifyTVar' entry.refCount (+ 1)
         pure (Just entry.session, Focus.Leave)
 
--- | Insert a new session with refcount 1, or if another thread inserted
--- first, increment the existing entry's refcount and return its MVar
--- (the provided MVar is discarded). Either way, returns the MVar that
--- is in the map.
+-- | Insert a new session with refcount 1, or if another thread
+-- inserted first, increment the existing entry's refcount and
+-- return its value (the provided value is discarded). Returns
+-- the value in the map and whether this call inserted it.
 insertOrAcquire ::
   Hashable key =>
-  MVar a ->
+  a ->
   key ->
   STMMap.Map key (SessionEntry a) ->
-  STM (MVar a)
-insertOrAcquire var =
+  STM (a, Bool)
+insertOrAcquire val =
   STMMap.focus $
     Focus.casesM
       do
         refVar <- newTVar 1
-        pure (var, Focus.Set (SessionEntry var refVar))
+        pure ((val, True), Focus.Set (SessionEntry val refVar))
       \entry -> do
         modifyTVar' entry.refCount (+ 1)
-        pure (entry.session, Focus.Leave)
+        pure ((entry.session, False), Focus.Leave)
 
 -- | Decrement the reference count and delete the entry if it reaches zero.
 release ::

--- a/backend/src/Hnefatafl/App/Storage.hs
+++ b/backend/src/Hnefatafl/App/Storage.hs
@@ -16,6 +16,7 @@ import Hnefatafl.Effect.Storage (
   deletePendingAction,
   insertMove,
   insertPendingAction,
+  setOnlineClockState,
   setOutcome,
  )
 import Hnefatafl.Game.Common (
@@ -37,6 +38,7 @@ persistEvents gameId time = traverse_ $ \case
   UndoDeclined -> deletePendingAction gameId
   OfferCancelled -> deletePendingAction gameId
   OfferAutoCancelled _ _ -> deletePendingAction gameId
+  ClockUpdated cs -> setOnlineClockState gameId cs
 
 -- | Recover AppliedMoves (with zobrist hashes) from stored GameMoves
 -- by replaying the move sequence through the C engine.

--- a/backend/src/Hnefatafl/Core/Data.hs
+++ b/backend/src/Hnefatafl/Core/Data.hs
@@ -51,7 +51,10 @@ import Data.Aeson (
 import Data.Aeson qualified as Aeson
 import Data.Char (toLower)
 import Data.OpenApi (ToSchema (..), genericDeclareNamedSchema)
+import Data.OpenApi qualified as OpenApi
 import Data.OpenApi.SchemaOptions (fromAesonOptions)
+import Language.Haskell.TH.Syntax (Lift)
+import Refined (NonNegative, Positive, Refined)
 import Web.HttpApiData (FromHttpApiData, ToHttpApiData)
 
 newtype PlayerId = PlayerId Text
@@ -183,7 +186,8 @@ playerColorOptions =
     }
 
 instance ToJSON PlayerColor where toJSON = genericToJSON playerColorOptions
-instance FromJSON PlayerColor where parseJSON = genericParseJSON playerColorOptions
+instance FromJSON PlayerColor where
+  parseJSON = genericParseJSON playerColorOptions
 instance ToSchema PlayerColor where
   declareNamedSchema = genericDeclareNamedSchema (fromAesonOptions playerColorOptions)
 
@@ -202,15 +206,28 @@ data GameMove = GameMove
   deriving (Show, Eq, Generic)
 
 newtype Seconds = Seconds {unSeconds :: Int}
-  deriving (Show, Eq, Generic)
-  deriving newtype (ToJSON, FromJSON, ToSchema)
+  deriving (Show, Eq, Ord, Generic, Lift)
+  deriving newtype (Num, ToJSON, FromJSON, ToSchema)
 
 data TimeControl = TimeControl
-  { initialTime :: Seconds
-  , increment :: Seconds
+  { initialTime :: Refined Positive Seconds
+  , increment :: Refined NonNegative Seconds
   }
   deriving (Show, Eq, Generic)
-  deriving anyclass (ToJSON, FromJSON, ToSchema)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance ToSchema (Refined Positive Seconds) where
+  declareNamedSchema _ = do
+    schema <- OpenApi._namedSchemaSchema <$> declareNamedSchema (Proxy @Seconds)
+    pure $ OpenApi.NamedSchema Nothing $ schema{OpenApi._schemaMinimum = Just 1}
+
+instance ToSchema (Refined NonNegative Seconds) where
+  declareNamedSchema _ = do
+    schema <- OpenApi._namedSchemaSchema <$> declareNamedSchema (Proxy @Seconds)
+    pure $ OpenApi.NamedSchema Nothing $ schema{OpenApi._schemaMinimum = Just 0}
+
+instance ToSchema TimeControl where
+  declareNamedSchema = genericDeclareNamedSchema (fromAesonOptions defaultOptions)
 
 newtype GameParticipantTokenId = GameParticipantTokenId Text
   deriving (Show, Eq)

--- a/backend/src/Hnefatafl/Core/Data.hs
+++ b/backend/src/Hnefatafl/Core/Data.hs
@@ -39,6 +39,8 @@ module Hnefatafl.Core.Data (
   secondsToRemainingTime,
   secondsToTimespan,
   nanosPerMillisecond,
+  remainingToMicroseconds,
+  remainingToMs,
 
   -- * Game Participant Token Types
   GameParticipantTokenId (..),
@@ -274,6 +276,16 @@ nanosPerSecond = 1_000_000_000
 
 nanosPerMillisecond :: Int64
 nanosPerMillisecond = 1_000_000
+
+-- | Convert remaining time to microseconds.
+remainingToMicroseconds :: RemainingTime -> Int
+remainingToMicroseconds rt =
+  fromIntegral (getTimespan (toTimespan rt) `div` 1000)
+
+-- | Convert remaining time to milliseconds.
+remainingToMs :: RemainingTime -> Int
+remainingToMs rt =
+  fromIntegral (getTimespan (toTimespan rt) `div` nanosPerMillisecond)
 
 data ClockState = ClockState
   { whiteRemaining :: RemainingTime

--- a/backend/src/Hnefatafl/Core/Data.hs
+++ b/backend/src/Hnefatafl/Core/Data.hs
@@ -38,6 +38,7 @@ module Hnefatafl.Core.Data (
   toTimespan,
   secondsToRemainingTime,
   secondsToTimespan,
+  nanosPerMillisecond,
 
   -- * Game Participant Token Types
   GameParticipantTokenId (..),
@@ -270,6 +271,9 @@ secondsToTimespan s =
 
 nanosPerSecond :: Int64
 nanosPerSecond = 1_000_000_000
+
+nanosPerMillisecond :: Int64
+nanosPerMillisecond = 1_000_000
 
 data ClockState = ClockState
   { whiteRemaining :: RemainingTime

--- a/backend/src/Hnefatafl/Core/Data.hs
+++ b/backend/src/Hnefatafl/Core/Data.hs
@@ -41,6 +41,7 @@ module Hnefatafl.Core.Data (
   nanosPerMillisecond,
   remainingToMicroseconds,
   remainingToMs,
+  timeToMs,
 
   -- * Game Participant Token Types
   GameParticipantTokenId (..),
@@ -50,7 +51,7 @@ module Hnefatafl.Core.Data (
   DomainMapping (..),
 ) where
 
-import Chronos (Time, Timespan (..))
+import Chronos (Time, Timespan (..), getTime)
 import Data.Aeson (
   FromJSON (..),
   ToJSON (..),
@@ -286,6 +287,10 @@ remainingToMicroseconds rt =
 remainingToMs :: RemainingTime -> Int
 remainingToMs rt =
   fromIntegral (getTimespan (toTimespan rt) `div` nanosPerMillisecond)
+
+-- | Convert an absolute time to Unix milliseconds.
+timeToMs :: Time -> Int
+timeToMs t = fromIntegral (getTime t `div` nanosPerMillisecond)
 
 data ClockState = ClockState
   { whiteRemaining :: RemainingTime

--- a/backend/src/Hnefatafl/Core/Data.hs
+++ b/backend/src/Hnefatafl/Core/Data.hs
@@ -30,6 +30,14 @@ module Hnefatafl.Core.Data (
   -- * Time Control Types
   Seconds (..),
   TimeControl (..),
+  ClockState (..),
+  RemainingTime,
+  mkRemainingTime,
+  deduct,
+  addIncrement,
+  toTimespan,
+  secondsToRemainingTime,
+  secondsToTimespan,
 
   -- * Game Participant Token Types
   GameParticipantTokenId (..),
@@ -39,7 +47,7 @@ module Hnefatafl.Core.Data (
   DomainMapping (..),
 ) where
 
-import Chronos (Time)
+import Chronos (Time, Timespan (..))
 import Data.Aeson (
   FromJSON (..),
   ToJSON (..),
@@ -54,7 +62,7 @@ import Data.OpenApi (ToSchema (..), genericDeclareNamedSchema)
 import Data.OpenApi qualified as OpenApi
 import Data.OpenApi.SchemaOptions (fromAesonOptions)
 import Language.Haskell.TH.Syntax (Lift)
-import Refined (NonNegative, Positive, Refined)
+import Refined (NonNegative, Positive, Refined, unrefine)
 import Web.HttpApiData (FromHttpApiData, ToHttpApiData)
 
 newtype PlayerId = PlayerId Text
@@ -228,6 +236,47 @@ instance ToSchema (Refined NonNegative Seconds) where
 
 instance ToSchema TimeControl where
   declareNamedSchema = genericDeclareNamedSchema (fromAesonOptions defaultOptions)
+
+-- | Non-negative duration of remaining time. Constructor is hidden;
+-- use 'mkRemainingTime', 'deduct', and 'addIncrement'.
+newtype RemainingTime = RemainingTime Timespan
+  deriving (Show, Eq, Ord)
+
+mkRemainingTime :: Timespan -> Maybe RemainingTime
+mkRemainingTime ts
+  | getTimespan ts >= 0 = Just (RemainingTime ts)
+  | otherwise = Nothing
+
+-- | Subtract elapsed time. Returns Nothing if time expired.
+deduct :: Timespan -> RemainingTime -> Maybe RemainingTime
+deduct elapsed (RemainingTime r)
+  | elapsed > r = Nothing
+  | otherwise =
+      Just (RemainingTime (Timespan (getTimespan r - getTimespan elapsed)))
+
+-- | Add a non-negative increment to remaining time.
+addIncrement :: Refined NonNegative Seconds -> RemainingTime -> RemainingTime
+addIncrement inc (RemainingTime r) = RemainingTime (r <> secondsToTimespan inc)
+
+toTimespan :: RemainingTime -> Timespan
+toTimespan (RemainingTime ts) = ts
+
+secondsToRemainingTime :: Refined Positive Seconds -> RemainingTime
+secondsToRemainingTime = RemainingTime . secondsToTimespan
+
+secondsToTimespan :: Refined p Seconds -> Timespan
+secondsToTimespan s =
+  Timespan (fromIntegral (unSeconds (unrefine s)) * nanosPerSecond)
+
+nanosPerSecond :: Int64
+nanosPerSecond = 1_000_000_000
+
+data ClockState = ClockState
+  { whiteRemaining :: RemainingTime
+  , blackRemaining :: RemainingTime
+  , turnStartedAt :: Time
+  }
+  deriving (Show, Eq, Generic)
 
 newtype GameParticipantTokenId = GameParticipantTokenId Text
   deriving (Show, Eq)

--- a/backend/src/Hnefatafl/Core/Data.hs
+++ b/backend/src/Hnefatafl/Core/Data.hs
@@ -27,6 +27,10 @@ module Hnefatafl.Core.Data (
   opponent,
   GameMove (..),
 
+  -- * Time Control Types
+  Seconds (..),
+  TimeControl (..),
+
   -- * Game Participant Token Types
   GameParticipantTokenId (..),
   GameParticipantToken (..),
@@ -196,6 +200,17 @@ data GameMove = GameMove
   , timestamp :: Time
   }
   deriving (Show, Eq, Generic)
+
+newtype Seconds = Seconds {unSeconds :: Int}
+  deriving (Show, Eq, Generic)
+  deriving newtype (ToJSON, FromJSON, ToSchema)
+
+data TimeControl = TimeControl
+  { initialTime :: Seconds
+  , increment :: Seconds
+  }
+  deriving (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 newtype GameParticipantTokenId = GameParticipantTokenId Text
   deriving (Show, Eq)

--- a/backend/src/Hnefatafl/Effect/Clock.hs
+++ b/backend/src/Hnefatafl/Effect/Clock.hs
@@ -16,6 +16,8 @@ data Clock :: Effect where
   Now :: Clock m Time
   -- | Block for the given number of microseconds.
   Delay :: Int -> Clock m ()
+  -- | Block until the clock reaches the given absolute time.
+  DelayUntil :: Time -> Clock m ()
   -- | Measure the duration of an action.
   Stopwatch :: m a -> Clock m (Timespan, a)
 

--- a/backend/src/Hnefatafl/Effect/Clock.hs
+++ b/backend/src/Hnefatafl/Effect/Clock.hs
@@ -12,7 +12,11 @@ import Effectful (Effect)
 import Effectful.TH (makeEffect)
 
 data Clock :: Effect where
+  -- | Current time.
   Now :: Clock m Time
+  -- | Block for the given number of microseconds.
+  Delay :: Int -> Clock m ()
+  -- | Measure the duration of an action.
   Stopwatch :: m a -> Clock m (Timespan, a)
 
 makeEffect ''Clock

--- a/backend/src/Hnefatafl/Effect/Storage.hs
+++ b/backend/src/Hnefatafl/Effect/Storage.hs
@@ -40,6 +40,8 @@ module Hnefatafl.Effect.Storage (
   deleteLastNMoves,
   setOnlineTimeControl,
   getOnlineTimeControl,
+  setOnlineClockState,
+  getOnlineClockState,
 
   -- * Effect
   Storage (..),
@@ -85,6 +87,8 @@ data StorageCmd a where
   DeleteLastNMoves :: GameId -> Int -> StorageCmd ()
   SetOnlineTimeControl :: GameId -> TimeControl -> StorageCmd ()
   GetOnlineTimeControl :: GameId -> StorageCmd (Maybe TimeControl)
+  SetOnlineClockState :: GameId -> ClockState -> StorageCmd ()
+  GetOnlineClockState :: GameId -> StorageCmd (Maybe ClockState)
 
 --------------------------------------------------------------------------------
 -- Transaction monad
@@ -195,6 +199,12 @@ setOnlineTimeControl gid tc = liftCmd $ SetOnlineTimeControl gid tc
 
 getOnlineTimeControl :: GameId -> StorageTx (Maybe TimeControl)
 getOnlineTimeControl = liftCmd . GetOnlineTimeControl
+
+setOnlineClockState :: GameId -> ClockState -> StorageTx ()
+setOnlineClockState gid cs = liftCmd $ SetOnlineClockState gid cs
+
+getOnlineClockState :: GameId -> StorageTx (Maybe ClockState)
+getOnlineClockState = liftCmd . GetOnlineClockState
 
 --------------------------------------------------------------------------------
 -- Effectful effect

--- a/backend/src/Hnefatafl/Effect/Storage.hs
+++ b/backend/src/Hnefatafl/Effect/Storage.hs
@@ -42,6 +42,9 @@ module Hnefatafl.Effect.Storage (
   getOnlineTimeControl,
   setOnlineClockState,
   getOnlineClockState,
+  listActiveTimedOnlineGames,
+  setTimeoutAt,
+  listExpiredTimeouts,
 
   -- * Effect
   Storage (..),
@@ -89,6 +92,9 @@ data StorageCmd a where
   GetOnlineTimeControl :: GameId -> StorageCmd (Maybe TimeControl)
   SetOnlineClockState :: GameId -> ClockState -> StorageCmd ()
   GetOnlineClockState :: GameId -> StorageCmd (Maybe ClockState)
+  ListActiveTimedOnlineGames :: StorageCmd [GameId]
+  SetTimeoutAt :: GameId -> Maybe Time -> StorageCmd ()
+  ListExpiredTimeouts :: Time -> StorageCmd [GameId]
 
 --------------------------------------------------------------------------------
 -- Transaction monad
@@ -205,6 +211,15 @@ setOnlineClockState gid cs = liftCmd $ SetOnlineClockState gid cs
 
 getOnlineClockState :: GameId -> StorageTx (Maybe ClockState)
 getOnlineClockState = liftCmd . GetOnlineClockState
+
+listActiveTimedOnlineGames :: StorageTx [GameId]
+listActiveTimedOnlineGames = liftCmd ListActiveTimedOnlineGames
+
+setTimeoutAt :: GameId -> Maybe Time -> StorageTx ()
+setTimeoutAt gid t = liftCmd $ SetTimeoutAt gid t
+
+listExpiredTimeouts :: Time -> StorageTx [GameId]
+listExpiredTimeouts = liftCmd . ListExpiredTimeouts
 
 --------------------------------------------------------------------------------
 -- Effectful effect

--- a/backend/src/Hnefatafl/Effect/Storage.hs
+++ b/backend/src/Hnefatafl/Effect/Storage.hs
@@ -38,6 +38,8 @@ module Hnefatafl.Effect.Storage (
   getPendingAction,
   deletePendingAction,
   deleteLastNMoves,
+  setOnlineTimeControl,
+  getOnlineTimeControl,
 
   -- * Effect
   Storage (..),
@@ -81,6 +83,8 @@ data StorageCmd a where
   GetPendingAction :: GameId -> StorageCmd (Maybe PendingAction)
   DeletePendingAction :: GameId -> StorageCmd ()
   DeleteLastNMoves :: GameId -> Int -> StorageCmd ()
+  SetOnlineTimeControl :: GameId -> TimeControl -> StorageCmd ()
+  GetOnlineTimeControl :: GameId -> StorageCmd (Maybe TimeControl)
 
 --------------------------------------------------------------------------------
 -- Transaction monad
@@ -185,6 +189,12 @@ deletePendingAction = liftCmd . DeletePendingAction
 
 deleteLastNMoves :: GameId -> Int -> StorageTx ()
 deleteLastNMoves gid n = liftCmd $ DeleteLastNMoves gid n
+
+setOnlineTimeControl :: GameId -> TimeControl -> StorageTx ()
+setOnlineTimeControl gid tc = liftCmd $ SetOnlineTimeControl gid tc
+
+getOnlineTimeControl :: GameId -> StorageTx (Maybe TimeControl)
+getOnlineTimeControl = liftCmd . GetOnlineTimeControl
 
 --------------------------------------------------------------------------------
 -- Effectful effect

--- a/backend/src/Hnefatafl/Effect/Trace.hs
+++ b/backend/src/Hnefatafl/Effect/Trace.hs
@@ -5,24 +5,29 @@
 module Hnefatafl.Effect.Trace (
   Trace (..),
   inSpan,
+  inSpanWithLink,
   addSpanAttribute,
   recordSpanException,
 
   -- * Re-exports for callers
   OT.ToAttribute,
+  OT.SpanContext,
 ) where
 
 import Effectful
 import Effectful.Dispatch.Dynamic (send)
 import OpenTelemetry.Attributes qualified as OT (ToAttribute)
+import OpenTelemetry.Trace.Core qualified as OT (SpanContext)
 
 -- | Custom tracing effect wrapping hs-opentelemetry-api. 'inSpan' always
 -- creates a span (as a child of the current thread-local context if one
--- is active, otherwise as a new root). 'addSpanAttribute' and
+-- is active, otherwise as a new root). 'inSpanWithLink' creates a root
+-- span with a link to a related span context. 'addSpanAttribute' and
 -- 'recordSpanException' act on whichever span is currently active in
 -- OpenTelemetry's thread-local context and are silent no-ops if none is.
 data Trace :: Effect where
   InSpan :: Text -> m a -> Trace m a
+  InSpanWithLink :: Text -> OT.SpanContext -> m a -> Trace m a
   AddSpanAttribute :: OT.ToAttribute v => Text -> v -> Trace m ()
   RecordSpanException :: SomeException -> Trace m ()
 
@@ -33,6 +38,13 @@ type instance DispatchOf Trace = Dynamic
 -- recorded on the span by the underlying OpenTelemetry bracket.
 inSpan :: (HasCallStack, Trace :> es) => Text -> Eff es a -> Eff es a
 inSpan name = send . InSpan name
+
+-- | Run an action inside a new root span that links to a related span
+-- context. The link expresses a causal relationship without
+-- parent-child hierarchy.
+inSpanWithLink ::
+  (HasCallStack, Trace :> es) => Text -> OT.SpanContext -> Eff es a -> Eff es a
+inSpanWithLink name ctx = send . InSpanWithLink name ctx
 
 -- | Add an attribute to the currently active span. No-op if no span is
 -- active.

--- a/backend/src/Hnefatafl/Game/Common.hs
+++ b/backend/src/Hnefatafl/Game/Common.hs
@@ -40,6 +40,7 @@ import Hnefatafl.Bindings (
  )
 import Hnefatafl.Core.Data (
   BlackWinCondition (..),
+  ClockState (..),
   ExternBoard (..),
   GameMove (..),
   Layer (..),
@@ -102,6 +103,7 @@ data DomainEvent
     -- action. Carries the offer type and offerer so consumers can
     -- distinguish which offer was lost.
     OfferAutoCancelled PendingActionType PlayerColor
+  | ClockUpdated ClockState
   deriving (Show, Eq)
 
 winner :: Outcome -> Maybe PlayerColor

--- a/backend/src/Hnefatafl/Game/Online.hs
+++ b/backend/src/Hnefatafl/Game/Online.hs
@@ -8,18 +8,25 @@ module Hnefatafl.Game.Online (
   Event (..),
   TransitionResult (..),
   pending,
+  updateClock,
   transition,
   reconstruct,
 ) where
 
 import Chronos (Time)
+import Torsor (difference)
 import Hnefatafl.Bindings (nextGameStateWithMovesTrusted)
 import Hnefatafl.Core.Data (
+  ClockState (..),
   ExternBoard,
   Move (..),
   MoveWithCaptures (..),
   Outcome (..),
   PlayerColor (..),
+  TimeControl (..),
+  RemainingTime,
+  addIncrement,
+  deduct,
  )
 import Hnefatafl.Game.Common (
   AppliedMove (..),
@@ -39,7 +46,7 @@ import Hnefatafl.Game.Common (
   validMovesForPosition,
   zobristHashes,
  )
-import Optics (AffineTraversal', gafield, (%), (.~), (?~))
+import Optics (AffineTraversal', Lens', gafield, traverseOf, (%), (.~), (?~))
 import Prelude hiding (State, state)
 
 data Phase
@@ -47,6 +54,7 @@ data Phase
       { turn :: PlayerColor
       , validMoves :: [MoveWithCaptures]
       , pending :: Maybe PendingAction
+      , clock :: Maybe (TimeControl, ClockState)
       }
   | Finished {outcome :: Outcome}
   deriving (Show, Eq, Generic)
@@ -69,7 +77,7 @@ data Event
   | AcceptDraw PlayerColor
   | DeclineDraw PlayerColor
   | RequestUndo PlayerColor
-  | AcceptUndo PlayerColor
+  | AcceptUndo PlayerColor Time
   | DeclineUndo PlayerColor
   deriving (Show, Eq)
 
@@ -80,48 +88,92 @@ data TransitionResult = TransitionResult
   deriving (Show, Eq)
 
 -- | Construct an Active state, computing valid moves from the position.
-mkActive :: ExternBoard -> [AppliedMove] -> Maybe PendingAction -> State
-mkActive board moves pa =
+mkActive ::
+  ExternBoard ->
+  [AppliedMove] ->
+  Maybe PendingAction ->
+  Maybe (TimeControl, ClockState) ->
+  State
+mkActive board moves pa clk =
   State
     board
     moves
-    (Active (currentTurn moves) (validMovesForPosition moves) pa)
+    (Active (currentTurn moves) (validMovesForPosition moves) pa clk)
+
+-- | End the game, clearing any pending actions.
+mkFinished :: State -> Maybe PendingAction -> Outcome -> TransitionResult
+mkFinished s pend outcome =
+  TransitionResult
+    (s & #phase .~ Finished outcome)
+    (clearPending pend <> [GameEnded outcome])
+
+remainingFor :: PlayerColor -> Lens' ClockState RemainingTime
+remainingFor White = #whiteRemaining
+remainingFor Black = #blackRemaining
+
+-- | Compute new clock state after a move. Deducts elapsed thinking
+-- time from the mover's remaining time and adds the Fischer increment.
+-- Returns Nothing if the mover's time has expired.
+updateClock ::
+  TimeControl ->
+  ClockState ->
+  PlayerColor ->
+  Time ->
+  Maybe ClockState
+updateClock tc cs mover moveTime =
+  traverseOf (remainingFor mover) update cs
+    <&> (#turnStartedAt .~ moveTime)
+ where
+  elapsed = max mempty (difference moveTime cs.turnStartedAt)
+  update r = addIncrement tc.increment <$> deduct elapsed r
 
 transition :: State -> Event -> Either TransitionError TransitionResult
 transition (State _ _ (Finished _)) = const $ Left GameAlreadyFinished
-transition s@(State board moves (Active turn validMoves pend)) = \case
+transition s@(State board moves (Active turn validMoves pend clk)) = \case
   MakeMove color move time
     | color /= turn -> Left NotYourTurn
     | move `notElem` map (.move) validMoves -> Left InvalidMove
-    | otherwise -> do
-        let hashes = zobristHashes moves
-        (moveResult, engineStatus, nextValidMoves) <-
-          first (const EngineError) $
-            nextGameStateWithMovesTrusted board (turn == Black) move hashes
-        let applied = mkAppliedMove moveResult time
-            moves' = moves <> [applied]
-        Right $ case outcomeFromEngine engineStatus of
-          Just outcome ->
-            TransitionResult
-              (State applied.boardAfter moves' (Finished outcome))
-              (MovePlayed applied : clearPending pend <> [GameEnded outcome])
-          Nothing ->
-            let (pending', cancelEvts) = cancelPending (opponent color) pend
-             in TransitionResult
-                  (State applied.boardAfter moves' (Active (opponent turn) nextValidMoves pending'))
-                  (MovePlayed applied : cancelEvts)
+    | otherwise -> case clk of
+        Just (tc, cs) -> case updateClock tc cs color time of
+          Nothing -> Right $ mkFinished s pend (TimedOut color)
+          Just cs' -> makeMove (Just (tc, cs'))
+        Nothing -> makeMove Nothing
+   where
+    makeMove clk' = do
+      (moveResult, engineStatus, nextValidMoves) <-
+        first (const EngineError) $
+          nextGameStateWithMovesTrusted
+            board
+            (turn == Black)
+            move
+            (zobristHashes moves)
+
+      let applied = mkAppliedMove moveResult time
+          moves' = moves <> [applied]
+          clockEvt = ClockUpdated . snd <$> clk'
+          (pending', cancelEvts) = cancelPending (opponent color) pend
+
+      Right $ case outcomeFromEngine engineStatus of
+        Just outcome ->
+          TransitionResult
+            (State applied.boardAfter moves' (Finished outcome))
+            ( MovePlayed applied
+                : maybeToList clockEvt
+                <> clearPending pend
+                <> [GameEnded outcome]
+            )
+        Nothing ->
+          TransitionResult
+            ( State
+                applied.boardAfter
+                moves'
+                (Active (opponent turn) nextValidMoves pending' clk')
+            )
+            (MovePlayed applied : maybeToList clockEvt <> cancelEvts)
   Resign color ->
-    let outcome = ResignedBy color
-     in Right $
-          TransitionResult
-            (s & #phase .~ Finished outcome)
-            (clearPending pend <> [GameEnded outcome])
+    Right $ mkFinished s pend (ResignedBy color)
   Timeout color ->
-    let outcome = TimedOut color
-     in Right $
-          TransitionResult
-            (s & #phase .~ Finished outcome)
-            (clearPending pend <> [GameEnded outcome])
+    Right $ mkFinished s pend (TimedOut color)
   OfferDraw color
     | isJust pend -> Left ActionAlreadyPending
     | otherwise ->
@@ -147,17 +199,18 @@ transition s@(State board moves (Active turn validMoves pend)) = \case
           TransitionResult
             (s & #phase % pending ?~ PendingAction UndoRequest color)
             [UndoRequested color]
-  AcceptUndo color -> case pend of
+  AcceptUndo color undoTime -> case pend of
     Just pa
       | pa.actionType == UndoRequest && pa.offeredBy /= color ->
           let undoCount = if turn == pa.offeredBy then 2 else 1
+              clk' = clk <&> second (\cs -> cs{turnStartedAt = undoTime})
            in case undoMoves undoCount moves of
                 Nothing -> Left NoMovesToUndo
                 Just moves' ->
                   let board' = currentBoard moves'
                    in Right $
                         TransitionResult
-                          (mkActive board' moves' Nothing)
+                          (mkActive board' moves' Nothing clk')
                           [OfferCancelled, MovesUndone undoCount]
     Just pa | pa.offeredBy == color -> Left CannotRespondToOwnOffer
     _ -> Left NoPendingOffer
@@ -169,6 +222,13 @@ transition s@(State board moves (Active turn validMoves pend)) = \case
 
 -- | Reconstruct state from persisted data
 reconstruct ::
-  ExternBoard -> [AppliedMove] -> Maybe Outcome -> Maybe PendingAction -> State
-reconstruct board moves (Just outcome) _ = State board moves (Finished outcome)
-reconstruct board moves Nothing pa = mkActive board moves pa
+  ExternBoard ->
+  [AppliedMove] ->
+  Maybe Outcome ->
+  Maybe PendingAction ->
+  Maybe (TimeControl, ClockState) ->
+  State
+reconstruct board moves (Just outcome) _ _ =
+  State board moves (Finished outcome)
+reconstruct board moves Nothing pa clk =
+  mkActive board moves pa clk

--- a/backend/src/Hnefatafl/Game/Online.hs
+++ b/backend/src/Hnefatafl/Game/Online.hs
@@ -8,13 +8,13 @@ module Hnefatafl.Game.Online (
   Event (..),
   TransitionResult (..),
   pending,
+  remainingFor,
   updateClock,
   transition,
   reconstruct,
 ) where
 
 import Chronos (Time)
-import Torsor (difference)
 import Hnefatafl.Bindings (nextGameStateWithMovesTrusted)
 import Hnefatafl.Core.Data (
   ClockState (..),
@@ -23,8 +23,8 @@ import Hnefatafl.Core.Data (
   MoveWithCaptures (..),
   Outcome (..),
   PlayerColor (..),
-  TimeControl (..),
   RemainingTime,
+  TimeControl (..),
   addIncrement,
   deduct,
  )
@@ -47,6 +47,7 @@ import Hnefatafl.Game.Common (
   zobristHashes,
  )
 import Optics (AffineTraversal', Lens', gafield, traverseOf, (%), (.~), (?~))
+import Torsor (difference)
 import Prelude hiding (State, state)
 
 data Phase
@@ -107,6 +108,7 @@ mkFinished s pend outcome =
     (s & #phase .~ Finished outcome)
     (clearPending pend <> [GameEnded outcome])
 
+-- | Lens into the remaining time for the given player color.
 remainingFor :: PlayerColor -> Lens' ClockState RemainingTime
 remainingFor White = #whiteRemaining
 remainingFor Black = #blackRemaining
@@ -159,8 +161,8 @@ transition s@(State board moves (Active turn validMoves pend clk)) = \case
             (State applied.boardAfter moves' (Finished outcome))
             ( MovePlayed applied
                 : maybeToList clockEvt
-                <> clearPending pend
-                <> [GameEnded outcome]
+                  <> clearPending pend
+                  <> [GameEnded outcome]
             )
         Nothing ->
           TransitionResult
@@ -172,8 +174,13 @@ transition s@(State board moves (Active turn validMoves pend clk)) = \case
             (MovePlayed applied : maybeToList clockEvt <> cancelEvts)
   Resign color ->
     Right $ mkFinished s pend (ResignedBy color)
-  Timeout color ->
-    Right $ mkFinished s pend (TimedOut color)
+  -- A stale TimeoutFired can arrive if the timer commits its
+  -- enqueue between the start of processing a move (which switches
+  -- turn) and the subsequent Async.cancel in manageTimer. Guard
+  -- against this by rejecting timeouts for the non-active player.
+  Timeout color
+    | color == turn -> Right $ mkFinished s pend (TimedOut color)
+    | otherwise -> Left NotYourTurn
   OfferDraw color
     | isJust pend -> Left ActionAlreadyPending
     | otherwise ->

--- a/backend/src/Hnefatafl/Game/Online.hs
+++ b/backend/src/Hnefatafl/Game/Online.hs
@@ -5,6 +5,7 @@
 module Hnefatafl.Game.Online (
   Phase (..),
   State (..),
+  GameClock (..),
   Event (..),
   TransitionResult (..),
   pending,
@@ -55,15 +56,24 @@ data Phase
       { turn :: PlayerColor
       , validMoves :: [MoveWithCaptures]
       , pending :: Maybe PendingAction
-      , clock :: Maybe (TimeControl, ClockState)
       }
   | Finished {outcome :: Outcome}
+  deriving (Show, Eq, Generic)
+
+-- | The game's clock. Immutable time-control configuration and the
+-- mutable running state travel together, so "timed" is a single
+-- invariant rather than two independent Maybes. It lives on 'State'
+-- (not 'Phase') because the configuration outlives the active phase.
+data GameClock
+  = Untimed
+  | Timed TimeControl ClockState
   deriving (Show, Eq, Generic)
 
 data State = State
   { board :: ExternBoard
   , moves :: [AppliedMove]
   , phase :: Phase
+  , clock :: GameClock
   }
   deriving (Show, Eq, Generic)
 
@@ -93,13 +103,14 @@ mkActive ::
   ExternBoard ->
   [AppliedMove] ->
   Maybe PendingAction ->
-  Maybe (TimeControl, ClockState) ->
+  GameClock ->
   State
 mkActive board moves pa clk =
   State
     board
     moves
-    (Active (currentTurn moves) (validMovesForPosition moves) pa clk)
+    (Active (currentTurn moves) (validMovesForPosition moves) pa)
+    clk
 
 -- | End the game, clearing any pending actions.
 mkFinished :: State -> Maybe PendingAction -> Outcome -> TransitionResult
@@ -130,20 +141,20 @@ updateClock tc cs mover moveTime =
   update r = addIncrement tc.increment <$> deduct elapsed r
 
 transition :: State -> Event -> Either TransitionError TransitionResult
-transition (State _ _ (Finished _)) = const $ Left GameAlreadyFinished
-transition s@(State board moves (Active turn validMoves pend clk)) = \case
+transition (State _ _ (Finished _) _) = const $ Left GameAlreadyFinished
+transition s@(State board moves (Active turn validMoves pend) clk) = \case
   MakeMove color move time
     | color /= turn -> Left NotYourTurn
     | move `notElem` map (.move) validMoves -> Left InvalidMove
     | otherwise -> case clk of
-        Just (tc, cs)
+        Timed tc cs
           -- First move: clock hasn't started yet. Set turnStartedAt
           -- so the opponent's clock begins from this point.
-          | null moves -> makeMove (Just (tc, cs{turnStartedAt = time}))
+          | null moves -> makeMove (Timed tc cs{turnStartedAt = time})
           | otherwise -> case updateClock tc cs color time of
               Nothing -> Right $ mkFinished s pend (TimedOut color)
-              Just cs' -> makeMove (Just (tc, cs'))
-        Nothing -> makeMove Nothing
+              Just cs' -> makeMove (Timed tc cs')
+        Untimed -> makeMove Untimed
    where
     makeMove clk' = do
       (moveResult, engineStatus, nextValidMoves) <-
@@ -156,13 +167,15 @@ transition s@(State board moves (Active turn validMoves pend clk)) = \case
 
       let applied = mkAppliedMove moveResult time
           moves' = moves <> [applied]
-          clockEvt = ClockUpdated . snd <$> clk'
+          clockEvt = case clk' of
+            Timed _ cs -> Just (ClockUpdated cs)
+            Untimed -> Nothing
           (pending', cancelEvts) = cancelPending (opponent color) pend
 
       Right $ case outcomeFromEngine engineStatus of
         Just outcome ->
           TransitionResult
-            (State applied.boardAfter moves' (Finished outcome))
+            (State applied.boardAfter moves' (Finished outcome) clk')
             ( MovePlayed applied
                 : maybeToList clockEvt
                   <> clearPending pend
@@ -173,7 +186,8 @@ transition s@(State board moves (Active turn validMoves pend clk)) = \case
             ( State
                 applied.boardAfter
                 moves'
-                (Active (opponent turn) nextValidMoves pending' clk')
+                (Active (opponent turn) nextValidMoves pending')
+                clk'
             )
             (MovePlayed applied : maybeToList clockEvt <> cancelEvts)
   Resign color ->
@@ -214,7 +228,9 @@ transition s@(State board moves (Active turn validMoves pend clk)) = \case
     Just pa
       | pa.actionType == UndoRequest && pa.offeredBy /= color ->
           let undoCount = if turn == pa.offeredBy then 2 else 1
-              clk' = clk <&> second (\cs -> cs{turnStartedAt = undoTime})
+              clk' = case clk of
+                Timed tc cs -> Timed tc cs{turnStartedAt = undoTime}
+                Untimed -> Untimed
            in case undoMoves undoCount moves of
                 Nothing -> Left NoMovesToUndo
                 Just moves' ->
@@ -237,9 +253,9 @@ reconstruct ::
   [AppliedMove] ->
   Maybe Outcome ->
   Maybe PendingAction ->
-  Maybe (TimeControl, ClockState) ->
+  GameClock ->
   State
-reconstruct board moves (Just outcome) _ _ =
-  State board moves (Finished outcome)
+reconstruct board moves (Just outcome) _ clk =
+  State board moves (Finished outcome) clk
 reconstruct board moves Nothing pa clk =
   mkActive board moves pa clk

--- a/backend/src/Hnefatafl/Game/Online.hs
+++ b/backend/src/Hnefatafl/Game/Online.hs
@@ -136,9 +136,13 @@ transition s@(State board moves (Active turn validMoves pend clk)) = \case
     | color /= turn -> Left NotYourTurn
     | move `notElem` map (.move) validMoves -> Left InvalidMove
     | otherwise -> case clk of
-        Just (tc, cs) -> case updateClock tc cs color time of
-          Nothing -> Right $ mkFinished s pend (TimedOut color)
-          Just cs' -> makeMove (Just (tc, cs'))
+        Just (tc, cs)
+          -- First move: clock hasn't started yet. Set turnStartedAt
+          -- so the opponent's clock begins from this point.
+          | null moves -> makeMove (Just (tc, cs{turnStartedAt = time}))
+          | otherwise -> case updateClock tc cs color time of
+              Nothing -> Right $ mkFinished s pend (TimedOut color)
+              Just cs' -> makeMove (Just (tc, cs'))
         Nothing -> makeMove Nothing
    where
     makeMove clk' = do

--- a/backend/src/Hnefatafl/Interpreter/Clock/IO.hs
+++ b/backend/src/Hnefatafl/Interpreter/Clock/IO.hs
@@ -5,6 +5,7 @@ module Hnefatafl.Interpreter.Clock.IO (
 ) where
 
 import Chronos qualified as C
+import Control.Concurrent (threadDelay)
 import Effectful
 import Effectful.Dispatch.Dynamic (interpret, localSeqUnliftIO)
 import Hnefatafl.Effect.Clock
@@ -12,5 +13,6 @@ import Hnefatafl.Effect.Clock
 runClockIO :: IOE :> es => Eff (Clock : es) a -> Eff es a
 runClockIO = interpret $ \env -> \case
   Now -> liftIO C.now
+  Delay us -> liftIO $ threadDelay us
   Stopwatch action -> localSeqUnliftIO env $ \unlift ->
     liftIO $ C.stopwatch (unlift action)

--- a/backend/src/Hnefatafl/Interpreter/Clock/IO.hs
+++ b/backend/src/Hnefatafl/Interpreter/Clock/IO.hs
@@ -4,15 +4,21 @@ module Hnefatafl.Interpreter.Clock.IO (
   runClockIO,
 ) where
 
+import Chronos (Timespan (..))
 import Chronos qualified as C
 import Control.Concurrent (threadDelay)
 import Effectful
 import Effectful.Dispatch.Dynamic (interpret, localSeqUnliftIO)
 import Hnefatafl.Effect.Clock
+import Torsor (difference)
 
 runClockIO :: IOE :> es => Eff (Clock : es) a -> Eff es a
 runClockIO = interpret $ \env -> \case
   Now -> liftIO C.now
   Delay us -> liftIO $ threadDelay us
+  DelayUntil target -> liftIO $ do
+    current <- C.now
+    let remainingNs = getTimespan (difference target current)
+    threadDelay $ max 0 (fromIntegral (remainingNs `div` 1000))
   Stopwatch action -> localSeqUnliftIO env $ \unlift ->
     liftIO $ C.stopwatch (unlift action)

--- a/backend/src/Hnefatafl/Interpreter/Clock/Test.hs
+++ b/backend/src/Hnefatafl/Interpreter/Clock/Test.hs
@@ -30,5 +30,9 @@ runClockTest timeVar = interpret $ \env -> \case
     STM.atomically $ do
       current <- STM.readTVar timeVar
       when (current < target) STM.retry
+  DelayUntil target ->
+    STM.atomically $ do
+      current <- STM.readTVar timeVar
+      when (current < target) STM.retry
   Stopwatch action -> localSeqUnliftIO env $ \unlift ->
     liftIO $ C.stopwatch (unlift action)

--- a/backend/src/Hnefatafl/Interpreter/Clock/Test.hs
+++ b/backend/src/Hnefatafl/Interpreter/Clock/Test.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE GADTs #-}
+
+module Hnefatafl.Interpreter.Clock.Test (
+  runClockTest,
+) where
+
+import Chronos (Time, Timespan (..))
+import Chronos qualified as C
+import Effectful
+import Effectful.Concurrent (Concurrent)
+import Effectful.Concurrent.STM qualified as STM
+import Effectful.Dispatch.Dynamic (interpret, localSeqUnliftIO)
+import Hnefatafl.Effect.Clock (Clock (..))
+import Torsor (add)
+
+-- | Test clock interpreter driven by a TVar. 'Now' reads the
+-- current controlled time. 'Delay' blocks via STM retry until
+-- the controlled time advances past the target. Tests advance
+-- time by writing to the TVar.
+runClockTest ::
+  (IOE :> es, Concurrent :> es) =>
+  TVar Time ->
+  Eff (Clock : es) a ->
+  Eff es a
+runClockTest timeVar = interpret $ \env -> \case
+  Now -> STM.atomically $ STM.readTVar timeVar
+  Delay us -> do
+    start <- STM.atomically $ STM.readTVar timeVar
+    let target = add (Timespan (fromIntegral us * 1000)) start
+    STM.atomically $ do
+      current <- STM.readTVar timeVar
+      when (current < target) STM.retry
+  Stopwatch action -> localSeqUnliftIO env $ \unlift ->
+    liftIO $ C.stopwatch (unlift action)

--- a/backend/src/Hnefatafl/Interpreter/Storage/SQLite.hs
+++ b/backend/src/Hnefatafl/Interpreter/Storage/SQLite.hs
@@ -210,6 +210,12 @@ dispatch = \case
     GameDb.setOnlineClockState (fromDomain gameId) cs
   GetOnlineClockState gameId ->
     GameDb.getOnlineClockState (fromDomain gameId)
+  ListActiveTimedOnlineGames ->
+    GameDb.listActiveTimedOnlineGames
+  SetTimeoutAt gameId timeout ->
+    GameDb.setTimeoutAt (fromDomain gameId) timeout
+  ListExpiredTimeouts currentTime ->
+    GameDb.listExpiredTimeouts currentTime
 
 interpretTx ::
   (IOE :> es, Trace :> es) =>
@@ -262,3 +268,6 @@ describeCmd = \case
   GetOnlineTimeControl gid -> ("GetOnlineTimeControl", "TimeControl", Just $ show gid)
   SetOnlineClockState gid _ -> ("SetOnlineClockState", "ClockState", Just $ show gid)
   GetOnlineClockState gid -> ("GetOnlineClockState", "ClockState", Just $ show gid)
+  ListActiveTimedOnlineGames -> ("ListActiveTimedOnlineGames", "Game", Nothing)
+  SetTimeoutAt gid _ -> ("SetTimeoutAt", "TimeoutAt", Just $ show gid)
+  ListExpiredTimeouts _ -> ("ListExpiredTimeouts", "Game", Nothing)

--- a/backend/src/Hnefatafl/Interpreter/Storage/SQLite.hs
+++ b/backend/src/Hnefatafl/Interpreter/Storage/SQLite.hs
@@ -5,7 +5,7 @@ module Hnefatafl.Interpreter.Storage.SQLite (
   withConnectionRecovery,
 ) where
 
-import Chronos (now)
+import Chronos (getTimespan, now)
 import Data.Unique (hashUnique, newUnique)
 import Database.SQLite.Simple (Connection, Query (..), close, execute_)
 import Effectful
@@ -14,10 +14,8 @@ import Effectful.Concurrent.MVar qualified as MVar
 import Effectful.Dispatch.Dynamic
 import Effectful.Exception (catchSync, throwIO, try)
 import Hnefatafl.Core.Data
-import Hnefatafl.Effect.Storage
-import Chronos (getTimespan)
 import Hnefatafl.Effect.Clock (Clock, stopwatch)
-import Hnefatafl.Metrics (HMetrics, Hs (..), observe)
+import Hnefatafl.Effect.Storage
 import Hnefatafl.Effect.Trace (Trace, addSpanAttribute, inSpan)
 import Hnefatafl.Exception (
   ConnectionUnrecoverableException (..),
@@ -39,6 +37,7 @@ import Hnefatafl.Interpreter.Storage.SQLite.Player
 import Hnefatafl.Interpreter.Storage.SQLite.Token
 import Hnefatafl.Interpreter.Storage.SQLite.Type ()
 import Hnefatafl.Interpreter.Storage.SQLite.Util
+import Hnefatafl.Metrics (HMetrics, Hs (..), observe)
 
 --------------------------------------------------------------------------------
 -- SQLite effect implementation
@@ -89,15 +88,13 @@ withSavepoint conn txAction = do
       -- ROLLBACK TO undoes the SP's writes; RELEASE pops it from the
       -- stack. Both must succeed for the SP to be gone.
       cleanupOk <-
-        ( rollback >> release >> pure True
-          )
+        (rollback >> release >> pure True)
           `catchSync` \(_ :: SomeException) -> pure False
       if cleanupOk
         then throwIO originalEx
         else do
           escalateOk <-
-            ( escalate >> pure True
-              )
+            (escalate >> pure True)
               `catchSync` \(_ :: SomeException) -> pure False
           if escalateOk
             then throwIO originalEx
@@ -209,6 +206,10 @@ dispatch = \case
     GameDb.setOnlineTimeControl (fromDomain gameId) tc
   GetOnlineTimeControl gameId ->
     GameDb.getOnlineTimeControl (fromDomain gameId)
+  SetOnlineClockState gameId cs ->
+    GameDb.setOnlineClockState (fromDomain gameId) cs
+  GetOnlineClockState gameId ->
+    GameDb.getOnlineClockState (fromDomain gameId)
 
 interpretTx ::
   (IOE :> es, Trace :> es) =>
@@ -259,3 +260,5 @@ describeCmd = \case
   DeleteLastNMoves gid n -> ("DeleteLastNMoves", "Move", Just $ show gid <> " last " <> show n)
   SetOnlineTimeControl gid _ -> ("SetOnlineTimeControl", "TimeControl", Just $ show gid)
   GetOnlineTimeControl gid -> ("GetOnlineTimeControl", "TimeControl", Just $ show gid)
+  SetOnlineClockState gid _ -> ("SetOnlineClockState", "ClockState", Just $ show gid)
+  GetOnlineClockState gid -> ("GetOnlineClockState", "ClockState", Just $ show gid)

--- a/backend/src/Hnefatafl/Interpreter/Storage/SQLite.hs
+++ b/backend/src/Hnefatafl/Interpreter/Storage/SQLite.hs
@@ -32,6 +32,7 @@ import Hnefatafl.Interpreter.Storage.SQLite.Game (
   listGamesDb,
   setOutcomeById,
  )
+import Hnefatafl.Interpreter.Storage.SQLite.Game qualified as GameDb
 import Hnefatafl.Interpreter.Storage.SQLite.Move qualified as MoveDb
 import Hnefatafl.Interpreter.Storage.SQLite.PendingAction qualified as PendingDb
 import Hnefatafl.Interpreter.Storage.SQLite.Player
@@ -204,6 +205,10 @@ dispatch = \case
     PendingDb.deletePendingActionDb (fromDomain gameId)
   DeleteLastNMoves gameId n ->
     MoveDb.deleteLastNMoves (fromDomain gameId) n
+  SetOnlineTimeControl gameId tc ->
+    GameDb.setOnlineTimeControl (fromDomain gameId) tc
+  GetOnlineTimeControl gameId ->
+    GameDb.getOnlineTimeControl (fromDomain gameId)
 
 interpretTx ::
   (IOE :> es, Trace :> es) =>
@@ -252,3 +257,5 @@ describeCmd = \case
   GetPendingAction gid -> ("GetPendingAction", "PendingAction", Just $ show gid)
   DeletePendingAction gid -> ("DeletePendingAction", "PendingAction", Just $ show gid)
   DeleteLastNMoves gid n -> ("DeleteLastNMoves", "Move", Just $ show gid <> " last " <> show n)
+  SetOnlineTimeControl gid _ -> ("SetOnlineTimeControl", "TimeControl", Just $ show gid)
+  GetOnlineTimeControl gid -> ("GetOnlineTimeControl", "TimeControl", Just $ show gid)

--- a/backend/src/Hnefatafl/Interpreter/Storage/SQLite/Game.hs
+++ b/backend/src/Hnefatafl/Interpreter/Storage/SQLite/Game.hs
@@ -9,6 +9,9 @@ module Hnefatafl.Interpreter.Storage.SQLite.Game (
   getOnlineTimeControl,
   setOnlineClockState,
   getOnlineClockState,
+  listActiveTimedOnlineGames,
+  setTimeoutAt,
+  listExpiredTimeouts,
 ) where
 
 import Chronos (Time, Timespan (..), getTimespan)
@@ -240,3 +243,33 @@ getOnlineClockState gameId =
       <*> mkRemainingTime (Timespan black)
       <*> pure tick
   toClockState _ = Nothing
+
+-- | Active online games with a clock (time control set, game not
+-- finished).
+listActiveTimedOnlineGames :: Connection -> IO [GameId]
+listActiveTimedOnlineGames conn =
+  map (GameId . fromOnly)
+    <$> query_
+      conn
+      "SELECT og.game_id FROM online_game og \
+      \JOIN game g ON og.game_id = g.id \
+      \WHERE og.white_remaining_ns IS NOT NULL \
+      \AND g.game_status IS NULL"
+
+setTimeoutAt :: GameIdDb -> Maybe Time -> Connection -> IO ()
+setTimeoutAt gameId timeout =
+  execute'
+    "UPDATE online_game SET timeout_at = ? WHERE game_id = ?"
+    (timeout, gameId)
+
+listExpiredTimeouts :: Time -> Connection -> IO [GameId]
+listExpiredTimeouts currentTime conn =
+  map (GameId . fromOnly)
+    <$> query
+      conn
+      "SELECT og.game_id FROM online_game og \
+      \JOIN game g ON og.game_id = g.id \
+      \WHERE og.timeout_at IS NOT NULL \
+      \AND og.timeout_at <= ? \
+      \AND g.game_status IS NULL"
+      (Only currentTime)

--- a/backend/src/Hnefatafl/Interpreter/Storage/SQLite/Game.hs
+++ b/backend/src/Hnefatafl/Interpreter/Storage/SQLite/Game.hs
@@ -7,9 +7,11 @@ module Hnefatafl.Interpreter.Storage.SQLite.Game (
   gameToDb,
   setOnlineTimeControl,
   getOnlineTimeControl,
+  setOnlineClockState,
+  getOnlineClockState,
 ) where
 
-import Chronos (Time)
+import Chronos (Time, Timespan (..), getTimespan)
 import Control.Exception (throwIO)
 import Database.SQLite.Simple
 import Hnefatafl.Core.Data
@@ -140,7 +142,8 @@ getGameById gameId conn = do
              h.owner_id,
              a.player_id, a.player_color, a.engine_id,
              o.white_player_id, o.white_name, o.black_player_id, o.black_name,
-             o.initial_seconds, o.increment_seconds
+             o.initial_seconds, o.increment_seconds,
+             o.white_remaining_ns, o.black_remaining_ns, o.turn_started_at
       FROM game g
       LEFT JOIN hotseat_game h ON g.id = h.game_id
       LEFT JOIN ai_game a ON g.id = a.game_id
@@ -160,7 +163,8 @@ listGamesDb conn = do
              h.owner_id,
              a.player_id, a.player_color, a.engine_id,
              o.white_player_id, o.white_name, o.black_player_id, o.black_name,
-             o.initial_seconds, o.increment_seconds
+             o.initial_seconds, o.increment_seconds,
+             o.white_remaining_ns, o.black_remaining_ns, o.turn_started_at
       FROM game g
       LEFT JOIN hotseat_game h ON g.id = h.game_id
       LEFT JOIN ai_game a ON g.id = a.game_id
@@ -204,3 +208,35 @@ getOnlineTimeControl gameId =
         (reallyUnsafeRefine (Seconds initial))
         (reallyUnsafeRefine (Seconds inc))
   toTimeControl _ = Nothing
+
+setOnlineClockState :: GameIdDb -> ClockState -> Connection -> IO ()
+setOnlineClockState gameId cs =
+  execute'
+    """
+    UPDATE online_game
+    SET white_remaining_ns = ?, black_remaining_ns = ?, turn_started_at = ?
+    WHERE game_id = ?
+    """
+    ( getTimespan (toTimespan cs.whiteRemaining)
+    , getTimespan (toTimespan cs.blackRemaining)
+    , cs.turnStartedAt
+    , gameId
+    )
+
+getOnlineClockState :: GameIdDb -> Connection -> IO (Maybe ClockState)
+getOnlineClockState gameId =
+  fmap toClockState
+    . selectSingle
+      """
+      SELECT white_remaining_ns, black_remaining_ns, turn_started_at
+      FROM online_game WHERE game_id = ?
+      """
+      (Only gameId)
+ where
+  toClockState :: (Maybe Int64, Maybe Int64, Maybe Time) -> Maybe ClockState
+  toClockState (Just white, Just black, Just tick) =
+    ClockState
+      <$> mkRemainingTime (Timespan white)
+      <*> mkRemainingTime (Timespan black)
+      <*> pure tick
+  toClockState _ = Nothing

--- a/backend/src/Hnefatafl/Interpreter/Storage/SQLite/Game.hs
+++ b/backend/src/Hnefatafl/Interpreter/Storage/SQLite/Game.hs
@@ -5,6 +5,8 @@ module Hnefatafl.Interpreter.Storage.SQLite.Game (
   setOutcomeById,
   deleteGameById,
   gameToDb,
+  setOnlineTimeControl,
+  getOnlineTimeControl,
 ) where
 
 import Chronos (Time)
@@ -135,7 +137,8 @@ getGameById gameId conn = do
       SELECT g.id, g.name, g.game_type, g.start_time, g.end_time, g.game_status, g.created_at,
              h.owner_id,
              a.player_id, a.player_color, a.engine_id,
-             o.white_player_id, o.white_name, o.black_player_id, o.black_name
+             o.white_player_id, o.white_name, o.black_player_id, o.black_name,
+             o.initial_seconds, o.increment_seconds
       FROM game g
       LEFT JOIN hotseat_game h ON g.id = h.game_id
       LEFT JOIN ai_game a ON g.id = a.game_id
@@ -154,7 +157,8 @@ listGamesDb conn = do
       SELECT g.id, g.name, g.game_type, g.start_time, g.end_time, g.game_status, g.created_at,
              h.owner_id,
              a.player_id, a.player_color, a.engine_id,
-             o.white_player_id, o.white_name, o.black_player_id, o.black_name
+             o.white_player_id, o.white_name, o.black_player_id, o.black_name,
+             o.initial_seconds, o.increment_seconds
       FROM game g
       LEFT JOIN hotseat_game h ON g.id = h.game_id
       LEFT JOIN ai_game a ON g.id = a.game_id
@@ -177,3 +181,21 @@ deleteGameById =
   execute'
     "DELETE FROM game WHERE id = ?"
     . Only
+
+setOnlineTimeControl :: GameIdDb -> TimeControl -> Connection -> IO ()
+setOnlineTimeControl gameId tc =
+  execute'
+    "UPDATE online_game SET initial_seconds = ?, increment_seconds = ? WHERE game_id = ?"
+    (unSeconds tc.initialTime, unSeconds tc.increment, gameId)
+
+getOnlineTimeControl :: GameIdDb -> Connection -> IO (Maybe TimeControl)
+getOnlineTimeControl gameId =
+  fmap toTimeControl
+    . selectSingle
+      "SELECT initial_seconds, increment_seconds FROM online_game WHERE game_id = ?"
+      (Only gameId)
+ where
+  toTimeControl :: (Maybe Int, Maybe Int) -> Maybe TimeControl
+  toTimeControl (Just initial, Just inc) =
+    Just $ TimeControl (Seconds initial) (Seconds inc)
+  toTimeControl _ = Nothing

--- a/backend/src/Hnefatafl/Interpreter/Storage/SQLite/Game.hs
+++ b/backend/src/Hnefatafl/Interpreter/Storage/SQLite/Game.hs
@@ -16,6 +16,8 @@ import Hnefatafl.Core.Data
 import Hnefatafl.Exception (DataIntegrityException (..))
 import Hnefatafl.Interpreter.Storage.SQLite.Type
 import Hnefatafl.Interpreter.Storage.SQLite.Util
+import Refined (unrefine)
+import Refined.Unsafe (reallyUnsafeRefine)
 
 --------------------------------------------------------------------------------
 -- Helpers
@@ -186,7 +188,7 @@ setOnlineTimeControl :: GameIdDb -> TimeControl -> Connection -> IO ()
 setOnlineTimeControl gameId tc =
   execute'
     "UPDATE online_game SET initial_seconds = ?, increment_seconds = ? WHERE game_id = ?"
-    (unSeconds tc.initialTime, unSeconds tc.increment, gameId)
+    (unSeconds (unrefine tc.initialTime), unSeconds (unrefine tc.increment), gameId)
 
 getOnlineTimeControl :: GameIdDb -> Connection -> IO (Maybe TimeControl)
 getOnlineTimeControl gameId =
@@ -197,5 +199,8 @@ getOnlineTimeControl gameId =
  where
   toTimeControl :: (Maybe Int, Maybe Int) -> Maybe TimeControl
   toTimeControl (Just initial, Just inc) =
-    Just $ TimeControl (Seconds initial) (Seconds inc)
+    Just $
+      TimeControl
+        (reallyUnsafeRefine (Seconds initial))
+        (reallyUnsafeRefine (Seconds inc))
   toTimeControl _ = Nothing

--- a/backend/src/Hnefatafl/Interpreter/Storage/SQLite/Type.hs
+++ b/backend/src/Hnefatafl/Interpreter/Storage/SQLite/Type.hs
@@ -186,6 +186,9 @@ data GameJoinRow = GameJoinRow
   , onlineBlackName :: Maybe Text
   , onlineInitialSeconds :: Maybe Int
   , onlineIncrementSeconds :: Maybe Int
+  , onlineWhiteRemainingNs :: Maybe Int64
+  , onlineBlackRemainingNs :: Maybe Int64
+  , onlineTurnStartedAt :: Maybe Time
   }
   deriving (Show, Generic, FromRow)
 

--- a/backend/src/Hnefatafl/Interpreter/Storage/SQLite/Type.hs
+++ b/backend/src/Hnefatafl/Interpreter/Storage/SQLite/Type.hs
@@ -184,6 +184,8 @@ data GameJoinRow = GameJoinRow
   , onlineWhiteName :: Maybe Text
   , onlineBlackPlayerId :: Maybe PlayerIdDb
   , onlineBlackName :: Maybe Text
+  , onlineInitialSeconds :: Maybe Int
+  , onlineIncrementSeconds :: Maybe Int
   }
   deriving (Show, Generic, FromRow)
 

--- a/backend/src/Hnefatafl/Interpreter/Trace/NoOp.hs
+++ b/backend/src/Hnefatafl/Interpreter/Trace/NoOp.hs
@@ -16,5 +16,7 @@ runTraceNoOp :: Eff (Trace : es) a -> Eff es a
 runTraceNoOp = interpret $ \env -> \case
   InSpan _ action ->
     localSeqUnlift env $ \unlift -> unlift action
+  InSpanWithLink _ _ action ->
+    localSeqUnlift env $ \unlift -> unlift action
   AddSpanAttribute _ _ -> pure ()
   RecordSpanException _ -> pure ()

--- a/backend/src/Hnefatafl/Interpreter/Trace/OTel.hs
+++ b/backend/src/Hnefatafl/Interpreter/Trace/OTel.hs
@@ -19,6 +19,8 @@ import OpenTelemetry.Context.ThreadLocal (
   getContext,
  )
 import OpenTelemetry.Trace (
+  NewLink (..),
+  SpanArguments (..),
   Tracer,
   addAttribute,
   defaultSpanArguments,
@@ -47,7 +49,11 @@ runTraceOTel ::
 runTraceOTel tracer = interpret $ \env -> \case
   InSpan name action ->
     localSeqUnlift env $ \unlift ->
-      bracket (acquire name) release (use unlift action)
+      bracket (acquire name defaultSpanArguments) release (use unlift action)
+  InSpanWithLink name linkCtx action ->
+    localSeqUnlift env $ \unlift ->
+      let args = defaultSpanArguments{links = [NewLink linkCtx mempty]}
+       in bracket (acquireRoot name args) release (use unlift action)
   AddSpanAttribute k v -> liftIO $ do
     mSpan <- lookupSpan <$> getContext
     for_ mSpan $ addAttribute' k v
@@ -57,11 +63,19 @@ runTraceOTel tracer = interpret $ \env -> \case
  where
   addAttribute' k v sp = addAttribute sp k v
   recordException' e sp = recordException sp mempty Nothing e
-  -- Create the span, push it onto the thread-local context, and remember
-  -- the parent span (if any) so we can restore it on release.
-  acquire name = liftIO $ do
+  -- Create a child span of the current context, push it onto the
+  -- thread-local context, and remember the parent span so we can
+  -- restore it on release.
+  acquire name args = liftIO $ do
     ctx <- getContext
-    sp <- createSpanWithoutCallStack tracer ctx name defaultSpanArguments
+    sp <- createSpanWithoutCallStack tracer ctx name args
+    _ <- attachContext (insertSpan sp ctx)
+    pure (lookupSpan ctx, sp)
+  -- Create a root span (no parent) with the given arguments. The
+  -- empty context ensures no parent-child relationship.
+  acquireRoot name args = liftIO $ do
+    ctx <- getContext
+    sp <- createSpanWithoutCallStack tracer mempty name args
     _ <- attachContext (insertSpan sp ctx)
     pure (lookupSpan ctx, sp)
   -- End the span and restore the parent span (or none) as the active one.

--- a/backend/src/Hnefatafl/Metrics.hs
+++ b/backend/src/Hnefatafl/Metrics.hs
@@ -83,6 +83,7 @@ recordMetrics mode = traverse_ $ \case
   UndoDeclined -> pure ()
   OfferCancelled -> pure ()
   OfferAutoCancelled _ _ -> pure ()
+  ClockUpdated _ -> pure ()
 
 -- | Render an Outcome as a prometheus label value.
 outcomeLabel :: Outcome -> Text

--- a/backend/src/Hnefatafl/Server.hs
+++ b/backend/src/Hnefatafl/Server.hs
@@ -12,16 +12,19 @@ import Control.Exception.Backtrace (
 import Control.Monad.Trans.Resource (allocate, runResourceT)
 import Database.SQLite.Simple (close, open)
 import Effectful (runEff)
-import Effectful.Concurrent (runConcurrent)
+import Effectful.Concurrent (runConcurrent, threadDelay)
+import Effectful.Concurrent.Async qualified as Async
 import Effectful.Error.Static (runErrorNoCallStack)
+import Effectful.Exception (catchSync)
 import Effectful.Katip (logTM, runKatipE)
 import Effectful.Servant (runWarpServerSettingsContext)
 import Hnefatafl.Api.Handlers (server)
 import Hnefatafl.Api.Routes (HnefataflAPI)
+import Hnefatafl.App.Online qualified as Online
 import Hnefatafl.Exception (guardExceptions)
 import Hnefatafl.Interpreter.Clock.IO (runClockIO)
-import Hnefatafl.Interpreter.Metrics.NoOp (runMetricsNoOp)
 import Hnefatafl.Interpreter.IdGen.UUIDv7 (runIdGenUUIDv7)
+import Hnefatafl.Interpreter.Metrics.NoOp (runMetricsNoOp)
 import Hnefatafl.Interpreter.Search.Local (runSearchLocal)
 import Hnefatafl.Interpreter.Storage.SQLite (runStorageSQLite)
 import Hnefatafl.Interpreter.Trace.OTel (runTraceOTel, setKatipTraceId)
@@ -70,13 +73,21 @@ runServer port logLevel = runResourceT $ do
       . runTraceOTel tracer
       . runMetricsNoOp
       . runClockIO
-                . runStorageSQLite connectionVar openConn
+      . runStorageSQLite connectionVar openConn
       . runIdGenUUIDv7
       . runSearchLocal qsem
       . runWebSocketIO
       $ do
         $(logTM) InfoS $
           ls @Text ("Starting Hnefatafl server on port " <> show port)
+        -- Hourly sweeper for timed games that expired without an
+        -- active session (e.g. after server restart or disconnect).
+        void $ Async.async $ forever $ do
+          threadDelay (3600 * 1_000_000)
+          Online.sweepExpiredTimeouts
+            `catchSync` \(ex :: SomeException) ->
+              $(logTM) ErrorS $
+                ls @Text ("sweeper failed: " <> show ex)
         runWarpServerSettingsContext @HnefataflAPI
           settings
           ctx

--- a/backend/test/Hnefatafl/App/Online/SerializationTest.hs
+++ b/backend/test/Hnefatafl/App/Online/SerializationTest.hs
@@ -1,7 +1,7 @@
 module Hnefatafl.App.Online.SerializationTest where
 
 import Chronos (Time (..), Timespan (..))
-import Hnefatafl.Api.Types.WS.Online (OnlineServerMessage (..))
+import Hnefatafl.Api.Types.WS.Online (ClockMs (..), OnlineServerMessage (..))
 import Hnefatafl.App.Online.Serialization (
   gameStateMessage,
   notificationsFor,
@@ -80,23 +80,20 @@ test_gameStateMessage :: TestTree
 test_gameStateMessage =
   testGroup
     "gameStateMessage clock fields"
-    [ testCase "timed game has Just clock values" $
+    [ testCase "timed game has Just clock" $
         case gameStateMessage testGameId Black timedState of
-          OnlineGameState{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs} -> do
-            whiteMs @?= Just 300_000
-            blackMs @?= Just 250_000
+          OnlineGameState{_clock = c} ->
+            c @?= Just (ClockMs 300_000 250_000)
           other -> fail $ "Expected OnlineGameState, got " <> show other
-    , testCase "untimed game has Nothing clock values" $
+    , testCase "untimed game has Nothing clock" $
         case gameStateMessage testGameId Black untimedState of
-          OnlineGameState{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs} -> do
-            whiteMs @?= Nothing
-            blackMs @?= Nothing
+          OnlineGameState{_clock = c} ->
+            c @?= Nothing
           other -> fail $ "Expected OnlineGameState, got " <> show other
-    , testCase "finished game has Nothing clock values" $
+    , testCase "finished game has Nothing clock" $
         case gameStateMessage testGameId Black finishedState of
-          OnlineGameState{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs} -> do
-            whiteMs @?= Nothing
-            blackMs @?= Nothing
+          OnlineGameState{_clock = c} ->
+            c @?= Nothing
           other -> fail $ "Expected OnlineGameState, got " <> show other
     ]
 
@@ -108,47 +105,41 @@ test_notificationsForClock =
         let am = dummyMove Black
             notifications = notificationsFor Black timedState [MovePlayed am]
         case notifications of
-          [(_, OnlineMoveMade{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs})] -> do
-            whiteMs @?= Just 300_000
-            blackMs @?= Just 250_000
+          [(_, OnlineMoveMade{_clock = c})] ->
+            c @?= Just (ClockMs 300_000 250_000)
           other -> fail $ "Expected one OnlineMoveMade, got " <> show other
     , testCase "MovePlayed on untimed game has Nothing clock" $ do
         let am = dummyMove Black
             notifications = notificationsFor Black untimedState [MovePlayed am]
         case notifications of
-          [(_, OnlineMoveMade{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs})] -> do
-            whiteMs @?= Nothing
-            blackMs @?= Nothing
+          [(_, OnlineMoveMade{_clock = c})] ->
+            c @?= Nothing
           other -> fail $ "Expected one OnlineMoveMade, got " <> show other
     , testCase "GameEnded on timed game includes clock" $ do
         let notifications =
               notificationsFor Black timedState [GameEnded (BlackWins KingCaptured)]
         case notifications of
-          (_, OnlineGameOver{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs}) : _ -> do
-            whiteMs @?= Just 300_000
-            blackMs @?= Just 250_000
+          (_, OnlineGameOver{_clock = c}) : _ ->
+            c @?= Just (ClockMs 300_000 250_000)
           other -> fail $ "Expected OnlineGameOver, got " <> show other
     , testCase "GameEnded on untimed game has Nothing clock" $ do
         let notifications =
               notificationsFor Black untimedState [GameEnded (BlackWins KingCaptured)]
         case notifications of
-          (_, OnlineGameOver{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs}) : _ -> do
-            whiteMs @?= Nothing
-            blackMs @?= Nothing
+          (_, OnlineGameOver{_clock = c}) : _ ->
+            c @?= Nothing
           other -> fail $ "Expected OnlineGameOver, got " <> show other
     , testCase "MovesUndone on timed game includes clock" $ do
         let notifications = notificationsFor Black timedState [MovesUndone 1]
         case notifications of
-          (_, OnlineUndoAccepted{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs}) : _ -> do
-            whiteMs @?= Just 300_000
-            blackMs @?= Just 250_000
+          (_, OnlineUndoAccepted{_clock = c}) : _ ->
+            c @?= Just (ClockMs 300_000 250_000)
           other -> fail $ "Expected OnlineUndoAccepted, got " <> show other
     , testCase "MovesUndone on untimed game has Nothing clock" $ do
         let notifications = notificationsFor Black untimedState [MovesUndone 1]
         case notifications of
-          (_, OnlineUndoAccepted{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs}) : _ -> do
-            whiteMs @?= Nothing
-            blackMs @?= Nothing
+          (_, OnlineUndoAccepted{_clock = c}) : _ ->
+            c @?= Nothing
           other -> fail $ "Expected OnlineUndoAccepted, got " <> show other
     , testCase "ClockUpdated sends OnlineClockUpdated to actor" $ do
         let notifications = notificationsFor Black timedState [ClockUpdated timedClock]

--- a/backend/test/Hnefatafl/App/Online/SerializationTest.hs
+++ b/backend/test/Hnefatafl/App/Online/SerializationTest.hs
@@ -34,7 +34,8 @@ timedClock =
   ClockState
     (mkRemaining 300)
     (mkRemaining 250)
-    (Time 0)
+    -- 1.5s past the epoch, so turnStartedAt serializes to 1500 ms.
+    (Time 1_500_000_000)
 
 timedState :: Online.State
 timedState =
@@ -83,7 +84,7 @@ test_gameStateMessage =
     [ testCase "timed game has Just clock" $
         case gameStateMessage testGameId Black timedState of
           OnlineGameState{_clock = c} ->
-            c @?= Just (ClockMs 300_000 250_000)
+            c @?= Just (ClockMs 300_000 250_000 1500)
           other -> fail $ "Expected OnlineGameState, got " <> show other
     , testCase "untimed game has Nothing clock" $
         case gameStateMessage testGameId Black untimedState of
@@ -106,7 +107,7 @@ test_notificationsForClock =
             notifications = notificationsFor Black timedState [MovePlayed am]
         case notifications of
           [(_, OnlineMoveMade{_clock = c})] ->
-            c @?= Just (ClockMs 300_000 250_000)
+            c @?= Just (ClockMs 300_000 250_000 1500)
           other -> fail $ "Expected one OnlineMoveMade, got " <> show other
     , testCase "MovePlayed on untimed game has Nothing clock" $ do
         let am = dummyMove Black
@@ -120,7 +121,7 @@ test_notificationsForClock =
               notificationsFor Black timedState [GameEnded (BlackWins KingCaptured)]
         case notifications of
           (_, OnlineGameOver{_clock = c}) : _ ->
-            c @?= Just (ClockMs 300_000 250_000)
+            c @?= Just (ClockMs 300_000 250_000 1500)
           other -> fail $ "Expected OnlineGameOver, got " <> show other
     , testCase "GameEnded on untimed game has Nothing clock" $ do
         let notifications =
@@ -133,7 +134,7 @@ test_notificationsForClock =
         let notifications = notificationsFor Black timedState [MovesUndone 1]
         case notifications of
           (_, OnlineUndoAccepted{_clock = c}) : _ ->
-            c @?= Just (ClockMs 300_000 250_000)
+            c @?= Just (ClockMs 300_000 250_000 1500)
           other -> fail $ "Expected OnlineUndoAccepted, got " <> show other
     , testCase "MovesUndone on untimed game has Nothing clock" $ do
         let notifications = notificationsFor Black untimedState [MovesUndone 1]
@@ -144,9 +145,17 @@ test_notificationsForClock =
     , testCase "ClockUpdated sends OnlineClockUpdated to actor" $ do
         let notifications = notificationsFor Black timedState [ClockUpdated timedClock]
         case notifications of
-          [(target, OnlineClockUpdated{_whiteMs = whiteMs, _blackMs = blackMs})] -> do
-            target @?= Black
-            whiteMs @?= 300_000
-            blackMs @?= 250_000
+          [ ( target
+              , OnlineClockUpdated
+                  { _whiteMs = whiteMs
+                  , _blackMs = blackMs
+                  , _turnStartedAtMs = turnStartedAtMs
+                  }
+              )
+            ] -> do
+              target @?= Black
+              whiteMs @?= 300_000
+              blackMs @?= 250_000
+              turnStartedAtMs @?= 1500
           other -> fail $ "Expected one OnlineClockUpdated, got " <> show other
     ]

--- a/backend/test/Hnefatafl/App/Online/SerializationTest.hs
+++ b/backend/test/Hnefatafl/App/Online/SerializationTest.hs
@@ -42,26 +42,26 @@ timedState =
   Online.State
     startBoard
     []
-    ( Online.Active
-        Black
-        (toList startBlackMoves)
-        Nothing
-        (Just (mkTC 300 5, timedClock))
-    )
+    (Online.Active Black (toList startBlackMoves) Nothing)
+    (Online.Timed (mkTC 300 5) timedClock)
 
 untimedState :: Online.State
 untimedState =
   Online.State
     startBoard
     []
-    (Online.Active Black (toList startBlackMoves) Nothing Nothing)
+    (Online.Active Black (toList startBlackMoves) Nothing)
+    Online.Untimed
 
+-- A finished timed game keeps its clock configuration but reports no
+-- live clock in messages.
 finishedState :: Online.State
 finishedState =
   Online.State
     startBoard
     []
     (Online.Finished (WhiteWins KingEscaped))
+    (Online.Timed (mkTC 300 5) timedClock)
 
 test_remainingToMs :: TestTree
 test_remainingToMs =

--- a/backend/test/Hnefatafl/App/Online/SerializationTest.hs
+++ b/backend/test/Hnefatafl/App/Online/SerializationTest.hs
@@ -5,7 +5,6 @@ import Hnefatafl.Api.Types.WS.Online (ClockMs (..), OnlineServerMessage (..))
 import Hnefatafl.App.Online.Serialization (
   gameStateMessage,
   notificationsFor,
-  remainingToMs,
  )
 import Hnefatafl.Bindings (startBlackMoves, startBoard)
 import Hnefatafl.Core.Data (
@@ -16,6 +15,7 @@ import Hnefatafl.Core.Data (
   PlayerColor (..),
   WhiteWinCondition (..),
   mkRemainingTime,
+  remainingToMs,
  )
 import Hnefatafl.Game.Common (
   DomainEvent (..),

--- a/backend/test/Hnefatafl/App/Online/SerializationTest.hs
+++ b/backend/test/Hnefatafl/App/Online/SerializationTest.hs
@@ -1,0 +1,161 @@
+module Hnefatafl.App.Online.SerializationTest where
+
+import Chronos (Time (..), Timespan (..))
+import Hnefatafl.Api.Types.WS.Online (OnlineServerMessage (..))
+import Hnefatafl.App.Online.Serialization (
+  gameStateMessage,
+  notificationsFor,
+  remainingToMs,
+ )
+import Hnefatafl.Bindings (startBlackMoves, startBoard)
+import Hnefatafl.Core.Data (
+  BlackWinCondition (..),
+  ClockState (..),
+  GameId (..),
+  Outcome (..),
+  PlayerColor (..),
+  WhiteWinCondition (..),
+  mkRemainingTime,
+ )
+import Hnefatafl.Game.Common (
+  DomainEvent (..),
+ )
+import Hnefatafl.Game.Online qualified as Online
+import Hnefatafl.Game.TestUtil (dummyMove, mkRemaining, mkTC)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+import Prelude hiding (State)
+
+testGameId :: GameId
+testGameId = GameId "test-game"
+
+timedClock :: ClockState
+timedClock =
+  ClockState
+    (mkRemaining 300)
+    (mkRemaining 250)
+    (Time 0)
+
+timedState :: Online.State
+timedState =
+  Online.State
+    startBoard
+    []
+    ( Online.Active
+        Black
+        (toList startBlackMoves)
+        Nothing
+        (Just (mkTC 300 5, timedClock))
+    )
+
+untimedState :: Online.State
+untimedState =
+  Online.State
+    startBoard
+    []
+    (Online.Active Black (toList startBlackMoves) Nothing Nothing)
+
+finishedState :: Online.State
+finishedState =
+  Online.State
+    startBoard
+    []
+    (Online.Finished (WhiteWins KingEscaped))
+
+test_remainingToMs :: TestTree
+test_remainingToMs =
+  testGroup
+    "remainingToMs"
+    [ testCase "converts seconds to milliseconds" $
+        remainingToMs (mkRemaining 300) @?= 300_000
+    , testCase "zero remaining maps to zero" $
+        remainingToMs (mkRemaining 0) @?= 0
+    , testCase "sub-second precision preserved" $
+        case mkRemainingTime (Timespan 1_500_000_000) of
+          Just rt -> remainingToMs rt @?= 1_500
+          Nothing -> fail "mkRemainingTime failed"
+    ]
+
+test_gameStateMessage :: TestTree
+test_gameStateMessage =
+  testGroup
+    "gameStateMessage clock fields"
+    [ testCase "timed game has Just clock values" $
+        case gameStateMessage testGameId Black timedState of
+          OnlineGameState{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs} -> do
+            whiteMs @?= Just 300_000
+            blackMs @?= Just 250_000
+          other -> fail $ "Expected OnlineGameState, got " <> show other
+    , testCase "untimed game has Nothing clock values" $
+        case gameStateMessage testGameId Black untimedState of
+          OnlineGameState{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs} -> do
+            whiteMs @?= Nothing
+            blackMs @?= Nothing
+          other -> fail $ "Expected OnlineGameState, got " <> show other
+    , testCase "finished game has Nothing clock values" $
+        case gameStateMessage testGameId Black finishedState of
+          OnlineGameState{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs} -> do
+            whiteMs @?= Nothing
+            blackMs @?= Nothing
+          other -> fail $ "Expected OnlineGameState, got " <> show other
+    ]
+
+test_notificationsForClock :: TestTree
+test_notificationsForClock =
+  testGroup
+    "notificationsFor clock fields"
+    [ testCase "MovePlayed on timed game includes clock" $ do
+        let am = dummyMove Black
+            notifications = notificationsFor Black timedState [MovePlayed am]
+        case notifications of
+          [(_, OnlineMoveMade{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs})] -> do
+            whiteMs @?= Just 300_000
+            blackMs @?= Just 250_000
+          other -> fail $ "Expected one OnlineMoveMade, got " <> show other
+    , testCase "MovePlayed on untimed game has Nothing clock" $ do
+        let am = dummyMove Black
+            notifications = notificationsFor Black untimedState [MovePlayed am]
+        case notifications of
+          [(_, OnlineMoveMade{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs})] -> do
+            whiteMs @?= Nothing
+            blackMs @?= Nothing
+          other -> fail $ "Expected one OnlineMoveMade, got " <> show other
+    , testCase "GameEnded on timed game includes clock" $ do
+        let notifications =
+              notificationsFor Black timedState [GameEnded (BlackWins KingCaptured)]
+        case notifications of
+          (_, OnlineGameOver{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs}) : _ -> do
+            whiteMs @?= Just 300_000
+            blackMs @?= Just 250_000
+          other -> fail $ "Expected OnlineGameOver, got " <> show other
+    , testCase "GameEnded on untimed game has Nothing clock" $ do
+        let notifications =
+              notificationsFor Black untimedState [GameEnded (BlackWins KingCaptured)]
+        case notifications of
+          (_, OnlineGameOver{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs}) : _ -> do
+            whiteMs @?= Nothing
+            blackMs @?= Nothing
+          other -> fail $ "Expected OnlineGameOver, got " <> show other
+    , testCase "MovesUndone on timed game includes clock" $ do
+        let notifications = notificationsFor Black timedState [MovesUndone 1]
+        case notifications of
+          (_, OnlineUndoAccepted{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs}) : _ -> do
+            whiteMs @?= Just 300_000
+            blackMs @?= Just 250_000
+          other -> fail $ "Expected OnlineUndoAccepted, got " <> show other
+    , testCase "MovesUndone on untimed game has Nothing clock" $ do
+        let notifications = notificationsFor Black untimedState [MovesUndone 1]
+        case notifications of
+          (_, OnlineUndoAccepted{_whiteRemainingMs = whiteMs, _blackRemainingMs = blackMs}) : _ -> do
+            whiteMs @?= Nothing
+            blackMs @?= Nothing
+          other -> fail $ "Expected OnlineUndoAccepted, got " <> show other
+    , testCase "ClockUpdated sends OnlineClockUpdated to actor" $ do
+        let notifications = notificationsFor Black timedState [ClockUpdated timedClock]
+        case notifications of
+          [(target, OnlineClockUpdated{_whiteMs = whiteMs, _blackMs = blackMs})] -> do
+            target @?= Black
+            whiteMs @?= 300_000
+            blackMs @?= 250_000
+          other -> fail $ "Expected one OnlineClockUpdated, got " <> show other
+    ]

--- a/backend/test/Hnefatafl/App/OnlineCreateTest.hs
+++ b/backend/test/Hnefatafl/App/OnlineCreateTest.hs
@@ -13,6 +13,7 @@ import Hnefatafl.Effect.Storage (
   runTransaction,
  )
 import Hnefatafl.Interpreter.Storage.SQLite.Util (withSharedDB)
+import Refined.Unsafe (reallyUnsafeRefine)
 import Test.Hspec (Spec, around, describe, it, shouldBe)
 
 spec_onlineCreate :: Spec
@@ -26,7 +27,10 @@ spec_onlineCreate = around withSharedDB $ do
 
     it "persists time control when provided" $ \connVar -> do
       runHotseatTest connVar $ do
-        let tc = TimeControl (Seconds 300) (Seconds 3)
+        let tc =
+              TimeControl
+                (reallyUnsafeRefine (Seconds 300))
+                (reallyUnsafeRefine (Seconds 3))
         result <- Online.createGame (Just tc)
         retrieved <- runTransaction $ getOnlineTimeControl result.game.gameId
         liftIO $ retrieved `shouldBe` Just tc

--- a/backend/test/Hnefatafl/App/OnlineCreateTest.hs
+++ b/backend/test/Hnefatafl/App/OnlineCreateTest.hs
@@ -1,0 +1,32 @@
+module Hnefatafl.App.OnlineCreateTest where
+
+import Hnefatafl.App.Online (CreateGameResult (..))
+import Hnefatafl.App.Online qualified as Online
+import Hnefatafl.App.TestUtil (runHotseatTest)
+import Hnefatafl.Core.Data (
+  Game (..),
+  Seconds (..),
+  TimeControl (..),
+ )
+import Hnefatafl.Effect.Storage (
+  getOnlineTimeControl,
+  runTransaction,
+ )
+import Hnefatafl.Interpreter.Storage.SQLite.Util (withSharedDB)
+import Test.Hspec (Spec, around, describe, it, shouldBe)
+
+spec_onlineCreate :: Spec
+spec_onlineCreate = around withSharedDB $ do
+  describe "online create game" $ do
+    it "creates an untimed game when no time control is provided" $ \connVar -> do
+      runHotseatTest connVar $ do
+        result <- Online.createGame Nothing
+        tc <- runTransaction $ getOnlineTimeControl result.game.gameId
+        liftIO $ tc `shouldBe` Nothing
+
+    it "persists time control when provided" $ \connVar -> do
+      runHotseatTest connVar $ do
+        let tc = TimeControl (Seconds 300) (Seconds 3)
+        result <- Online.createGame (Just tc)
+        retrieved <- runTransaction $ getOnlineTimeControl result.game.gameId
+        liftIO $ retrieved `shouldBe` Just tc

--- a/backend/test/Hnefatafl/App/OnlineSessionTest.hs
+++ b/backend/test/Hnefatafl/App/OnlineSessionTest.hs
@@ -125,6 +125,9 @@ data ConnectedPlayer = ConnectedPlayer
   , wsThread :: Async.Async ()
   }
 
+sendMsg :: MonadIO m => Player -> OnlineClientMessage -> m ()
+sendMsg player msg = liftIO $ player.send msg
+
 -- | Connect a player via the full handleWebSocket path.
 connectPlayer ::
   TestEff es =>
@@ -164,8 +167,7 @@ withBothPlayersTimed action connVar =
     (white, _) <- connectPlayer game game.result.whiteToken
     (black, _) <- connectPlayer game game.result.blackToken
     _ <-
-      liftIO $
-        expectMessages white.player.inbox ["opponentJoined"] black.player.inbox []
+      expectMessages white.player.inbox ["opponentJoined"] black.player.inbox []
     action clock white.player black.player
     disconnectPlayer white
     disconnectPlayer black
@@ -181,8 +183,7 @@ withBothPlayersUsing setup action connVar =
     (white, _) <- connectPlayer game game.result.whiteToken
     (black, _) <- connectPlayer game game.result.blackToken
     _ <-
-      liftIO $
-        expectMessages white.player.inbox ["opponentJoined"] black.player.inbox []
+      expectMessages white.player.inbox ["opponentJoined"] black.player.inbox []
     action white.player black.player
     disconnectPlayer white
     disconnectPlayer black
@@ -214,22 +215,22 @@ spec_onlineSession = around withSharedDB $ do
         disconnectPlayer black
 
     it "delivers move to opponent" $ withBothPlayers $ \white black -> do
-      liftIO $ black.send (validMoves !! 0)
-      _ <- liftIO $ expectMessages white.inbox ["moveMade"] black.inbox []
+      sendMsg black (validMoves !! 0)
+      _ <- expectMessages white.inbox ["moveMade"] black.inbox []
       pass
 
     it "sends error for invalid move without crashing" $
       withBothPlayers $ \white black -> do
-        liftIO $ white.send (validMoves !! 1)
-        _ <- liftIO $ expectMessages white.inbox ["error"] black.inbox []
-        liftIO $ black.send (validMoves !! 0)
-        _ <- liftIO $ expectMessages white.inbox ["moveMade"] black.inbox []
+        sendMsg white (validMoves !! 1)
+        _ <- expectMessages white.inbox ["error"] black.inbox []
+        sendMsg black (validMoves !! 0)
+        _ <- expectMessages white.inbox ["moveMade"] black.inbox []
         pass
 
     it "resign ends the game and notifies both" $
       withBothPlayers $ \white black -> do
-        liftIO $ black.send OnlineResign
-        _ <- liftIO $ expectMessages white.inbox ["gameOver"] black.inbox ["gameOver"]
+        sendMsg black OnlineResign
+        _ <- expectMessages white.inbox ["gameOver"] black.inbox ["gameOver"]
         pass
 
     it "disconnect notifies remaining player" $ \connVar -> do
@@ -254,7 +255,7 @@ spec_onlineSession = around withSharedDB $ do
         _ <-
           liftIO $
             expectMessages white.player.inbox ["opponentJoined"] black.player.inbox []
-        liftIO $ black.player.send (validMoves !! 0)
+        sendMsg black.player (validMoves !! 0)
         _ <-
           liftIO $
             expectMessages white.player.inbox ["moveMade"] black.player.inbox []
@@ -275,17 +276,17 @@ spec_onlineSession = around withSharedDB $ do
 
     it "multiple moves maintain correct turn order" $
       withBothPlayers $ \white black -> do
-        liftIO $ black.send (validMoves !! 0)
-        _ <- liftIO $ expectMessages white.inbox ["moveMade"] black.inbox []
-        liftIO $ white.send (validMoves !! 1)
-        _ <- liftIO $ expectMessages black.inbox ["moveMade"] white.inbox []
-        liftIO $ black.send (validMoves !! 2)
-        _ <- liftIO $ expectMessages white.inbox ["moveMade"] black.inbox []
+        sendMsg black (validMoves !! 0)
+        _ <- expectMessages white.inbox ["moveMade"] black.inbox []
+        sendMsg white (validMoves !! 1)
+        _ <- expectMessages black.inbox ["moveMade"] white.inbox []
+        sendMsg black (validMoves !! 2)
+        _ <- expectMessages white.inbox ["moveMade"] black.inbox []
         pass
 
     it "timeout fires and ends timed game" $
       withBothPlayersTimed $ \clock white black -> do
-        liftIO $ black.send (validMoves !! 0)
+        sendMsg black (validMoves !! 0)
         _ <-
           liftIO $
             expectMessages white.inbox ["moveMade"] black.inbox ["clockUpdated"]
@@ -298,19 +299,19 @@ spec_onlineSession = around withSharedDB $ do
 
     it "move resets timeout timer" $
       withBothPlayersTimed $ \clock white black -> do
-        liftIO $ black.send (validMoves !! 0)
+        sendMsg black (validMoves !! 0)
         _ <-
           liftIO $
             expectMessages white.inbox ["moveMade"] black.inbox ["clockUpdated"]
         -- Advance 800ms (not enough to timeout)
         STM.atomically $ STM.modifyTVar' clock (add (Timespan 800_000_000))
-        liftIO $ white.send (validMoves !! 1)
+        sendMsg white (validMoves !! 1)
         _ <-
           liftIO $
             expectMessages black.inbox ["moveMade"] white.inbox ["clockUpdated"]
         -- Advance another 800ms (1.6s total > 1s, but timer was reset)
         STM.atomically $ STM.modifyTVar' clock (add (Timespan 800_000_000))
-        liftIO $ black.send (validMoves !! 2)
+        sendMsg black (validMoves !! 2)
         _ <-
           liftIO $
             expectMessages white.inbox ["moveMade"] black.inbox ["clockUpdated"]
@@ -318,12 +319,12 @@ spec_onlineSession = around withSharedDB $ do
 
     it "resignation cancels pending timeout" $
       withBothPlayersTimed $ \clock white black -> do
-        liftIO $ black.send (validMoves !! 0)
+        sendMsg black (validMoves !! 0)
         _ <-
           liftIO $
             expectMessages white.inbox ["moveMade"] black.inbox ["clockUpdated"]
         -- White's clock is ticking. Black resigns before timeout.
-        liftIO $ black.send OnlineResign
+        sendMsg black OnlineResign
         _ <-
           liftIO $
             expectMessages white.inbox ["gameOver"] black.inbox ["gameOver"]
@@ -335,14 +336,14 @@ spec_onlineSession = around withSharedDB $ do
 
     it "draw offer does not reset timeout" $
       withBothPlayersTimed $ \clock white black -> do
-        liftIO $ black.send (validMoves !! 0)
+        sendMsg black (validMoves !! 0)
         _ <-
           liftIO $
             expectMessages white.inbox ["moveMade"] black.inbox ["clockUpdated"]
         -- Advance 800ms
         STM.atomically $ STM.modifyTVar' clock (add (Timespan 800_000_000))
         -- White offers a draw (no clock change, timer should NOT reset)
-        liftIO $ white.send OnlineOfferDraw
+        sendMsg white OnlineOfferDraw
         _ <-
           liftIO $
             expectMessages black.inbox ["drawOffered"] white.inbox []
@@ -353,3 +354,75 @@ spec_onlineSession = around withSharedDB $ do
           liftIO $
             expectMessages white.inbox ["gameOver"] black.inbox ["gameOver"]
         pass
+
+    it "reconnect recovers timer for timed game" $ \connVar -> do
+      runOnlineTestTimed connVar $ \clock -> do
+        game <- setupTimedGame
+        (white, _) <- connectPlayer game game.result.whiteToken
+        (black, _) <- connectPlayer game game.result.blackToken
+        _ <-
+          liftIO $
+            expectMessages white.player.inbox ["opponentJoined"] black.player.inbox []
+        sendMsg black.player (validMoves !! 0)
+        _ <-
+          liftIO $
+            expectMessages
+              white.player.inbox
+              ["moveMade"]
+              black.player.inbox
+              ["clockUpdated"]
+        -- Disconnect both to clear the session. The timer is
+        -- cancelled when both players leave; recoverTimer restarts
+        -- it on reconnect.
+        disconnectPlayer white
+        _ <-
+          liftIO $
+            expectMessages black.player.inbox ["opponentLeft"] white.player.inbox []
+        disconnectPlayer black
+        -- Reconnect both — new session, recoverTimer spawns timer
+        (white2, _) <- connectPlayer game game.result.whiteToken
+        (black2, _) <- connectPlayer game game.result.blackToken
+        _ <-
+          liftIO $
+            expectMessages white2.player.inbox ["opponentJoined"] black2.player.inbox []
+        -- Advance clock past timeout
+        STM.atomically $ STM.modifyTVar' clock (add (Timespan 1_200_000_000))
+        -- Should receive gameOver
+        _ <-
+          liftIO $
+            expectMessages white2.player.inbox ["gameOver"] black2.player.inbox ["gameOver"]
+        disconnectPlayer white2
+        disconnectPlayer black2
+
+    it "reconnect fires timeout immediately if time expired" $ \connVar -> do
+      runOnlineTestTimed connVar $ \clock -> do
+        game <- setupTimedGame
+        (white, _) <- connectPlayer game game.result.whiteToken
+        (black, _) <- connectPlayer game game.result.blackToken
+        _ <-
+          liftIO $
+            expectMessages white.player.inbox ["opponentJoined"] black.player.inbox []
+        sendMsg black.player (validMoves !! 0)
+        _ <-
+          liftIO $
+            expectMessages
+              white.player.inbox
+              ["moveMade"]
+              black.player.inbox
+              ["clockUpdated"]
+        -- Disconnect both to clear the session and cancel the
+        -- in-memory timer.
+        disconnectPlayer white
+        _ <-
+          liftIO $
+            expectMessages black.player.inbox ["opponentLeft"] white.player.inbox []
+        disconnectPlayer black
+        -- Advance clock past timeout BEFORE reconnect
+        STM.atomically $ STM.modifyTVar' clock (add (Timespan 2_000_000_000))
+        -- Reconnect — recoverTimer detects expired time and fires
+        -- timeout immediately
+        (white2, _) <- connectPlayer game game.result.whiteToken
+        _ <-
+          liftIO $
+            expectMessages white2.player.inbox ["gameOver"] black.player.inbox []
+        disconnectPlayer white2

--- a/backend/test/Hnefatafl/App/OnlineSessionTest.hs
+++ b/backend/test/Hnefatafl/App/OnlineSessionTest.hs
@@ -2,9 +2,11 @@ module Hnefatafl.App.OnlineSessionTest where
 
 import Data.List ((!!))
 
+import Chronos (Time (..), Timespan (..))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KeyMap
+import Database.SQLite.Simple (Connection)
 import Effectful (Eff, IOE, (:>))
 import Effectful.Concurrent (Concurrent)
 import Effectful.Concurrent.Async qualified as Async
@@ -12,32 +14,38 @@ import Effectful.Concurrent.STM qualified as STM
 import Effectful.Katip (KatipE)
 import Hnefatafl.Api.Types (Position (..))
 import Hnefatafl.Api.Types.WS.Online (OnlineClientMessage (..))
-import Hnefatafl.Core.Data (Move (..), MoveResult (..))
 import Hnefatafl.App.Online (CreateGameResult (..), GameSessions)
 import Hnefatafl.App.Online qualified as Online
 import Hnefatafl.App.TestUtil (
+  Inbox (..),
   TestConnPair (..),
   clientRecvJSON,
   clientSendAuth,
   clientSendMsg,
-  expectFrom,
+  expectMessages,
   mkTestConnPair,
   runOnlineTest,
+  runOnlineTestTimed,
  )
 import Hnefatafl.Core.Data (
   GameParticipantToken (..),
+  Move (..),
+  MoveResult (..),
+  Seconds (..),
+  TimeControl (..),
  )
-import TestUtil (realMoveResults)
 import Hnefatafl.Effect.Clock (Clock)
 import Hnefatafl.Effect.IdGen (IdGen)
 import Hnefatafl.Effect.Storage (Storage)
 import Hnefatafl.Effect.Trace (Trace)
 import Hnefatafl.Effect.WebSocket (WebSocket)
-import Database.SQLite.Simple (Connection)
 import Hnefatafl.Interpreter.Storage.SQLite.Util (withSharedDB)
 import Hnefatafl.Metrics (HMetrics)
+import Refined.Unsafe (reallyUnsafeRefine)
 import StmContainers.Map qualified as STMMap
 import Test.Hspec (Spec, around, describe, it, shouldBe)
+import TestUtil (realMoveResults)
+import Torsor (add)
 
 -------------------------------------------------------------------------------
 -- Move fixtures from a known valid game. Alternates black/white.
@@ -45,7 +53,11 @@ import Test.Hspec (Spec, around, describe, it, shouldBe)
 validMoves :: [OnlineClientMessage]
 validMoves =
   map
-    (\mr -> OnlineMove (Position $ fromIntegral mr.move.orig) (Position $ fromIntegral mr.move.dest))
+    ( \mr ->
+        OnlineMove
+          (Position $ fromIntegral mr.move.orig)
+          (Position $ fromIntegral mr.move.dest)
+    )
     (toList realMoveResults)
 
 -------------------------------------------------------------------------------
@@ -82,20 +94,38 @@ data TestGame = TestGame
   , result :: CreateGameResult
   }
 
--- | Create a game with a shared session map.
+-- | Create an untimed game with a shared session map.
 setupGame :: TestEff es => Eff es TestGame
 setupGame = do
   sessions <- STM.atomically STMMap.new
   result <- Online.createGame Nothing
   pure TestGame{sessions, result}
 
+-- | Create a timed game with 1-second clock and 0 increment.
+setupTimedGame :: TestEff es => Eff es TestGame
+setupTimedGame = do
+  sessions <- STM.atomically STMMap.new
+  let tc =
+        TimeControl
+          (reallyUnsafeRefine (Seconds 1))
+          (reallyUnsafeRefine (Seconds 0))
+  result <- Online.createGame (Just tc)
+  pure TestGame{sessions, result}
+
+-- | The test-facing handle for a connected player. Contains only
+-- what test bodies need: a way to send and a way to receive.
+data Player = Player
+  { inbox :: Inbox
+  , send :: OnlineClientMessage -> IO ()
+  }
+
+-- Internal: full connection state needed for lifecycle management.
 data ConnectedPlayer = ConnectedPlayer
-  { conn :: TestConnPair
+  { player :: Player
   , wsThread :: Async.Async ()
   }
 
 -- | Connect a player via the full handleWebSocket path.
--- Authenticates and returns after receiving the initial game state.
 connectPlayer ::
   TestEff es =>
   TestGame ->
@@ -103,32 +133,57 @@ connectPlayer ::
   Eff es (ConnectedPlayer, Aeson.Value)
 connectPlayer game token = do
   tc <- liftIO mkTestConnPair
-  wsThread <- Async.async $
-    Online.handleWebSocket game.sessions tc.connection
+  wsThread <-
+    Async.async $
+      Online.handleWebSocket game.sessions tc.connection
   liftIO $ clientSendAuth tc token.token
   initialState <- liftIO $ clientRecvJSON tc
-  pure (ConnectedPlayer{conn = tc, wsThread}, initialState)
+  let player = Player{inbox = Inbox tc.serverToClient, send = clientSendMsg tc}
+  pure (ConnectedPlayer{player, wsThread}, initialState)
 
 disconnectPlayer :: Concurrent :> es => ConnectedPlayer -> Eff es ()
 disconnectPlayer = Async.cancel . (.wsThread)
 
--- | Connect both players, drain the opponentJoined notification,
--- run an action, then disconnect both. The action receives the
--- game setup and both players with clean message queues.
+-- | Connect both players, drain opponentJoined, run an action
+-- with the two Player handles, then disconnect both.
 withBothPlayers ::
-  ( forall es.
-    TestEff es =>
-    TestGame -> ConnectedPlayer -> ConnectedPlayer -> Eff es ()
-  ) ->
+  (forall es. TestEff es => Player -> Player -> Eff es ()) ->
   MVar Connection ->
   IO ()
-withBothPlayers action connVar =
-  runOnlineTest connVar $ do
-    game <- setupGame
+withBothPlayers = withBothPlayersUsing setupGame
+
+-- | Like withBothPlayers but for timed games with a controllable
+-- test clock. The action receives the clock TVar to advance time.
+withBothPlayersTimed ::
+  (forall es. TestEff es => TVar Time -> Player -> Player -> Eff es ()) ->
+  MVar Connection ->
+  IO ()
+withBothPlayersTimed action connVar =
+  runOnlineTestTimed connVar $ \clock -> do
+    game <- setupTimedGame
     (white, _) <- connectPlayer game game.result.whiteToken
     (black, _) <- connectPlayer game game.result.blackToken
-    _ <- liftIO $ clientRecvJSON white.conn -- opponentJoined
-    action game white black
+    _ <-
+      liftIO $
+        expectMessages white.player.inbox ["opponentJoined"] black.player.inbox []
+    action clock white.player black.player
+    disconnectPlayer white
+    disconnectPlayer black
+
+withBothPlayersUsing ::
+  (forall es. TestEff es => Eff es TestGame) ->
+  (forall es. TestEff es => Player -> Player -> Eff es ()) ->
+  MVar Connection ->
+  IO ()
+withBothPlayersUsing setup action connVar =
+  runOnlineTest connVar $ do
+    game <- setup
+    (white, _) <- connectPlayer game game.result.whiteToken
+    (black, _) <- connectPlayer game game.result.blackToken
+    _ <-
+      liftIO $
+        expectMessages white.player.inbox ["opponentJoined"] black.player.inbox []
+    action white.player black.player
     disconnectPlayer white
     disconnectPlayer black
 
@@ -152,43 +207,43 @@ spec_onlineSession = around withSharedDB $ do
         game <- setupGame
         (white, _) <- connectPlayer game game.result.whiteToken
         (black, _) <- connectPlayer game game.result.blackToken
-        msg <- liftIO $ clientRecvJSON white.conn
-        liftIO $ msgType msg `shouldBe` Just "opponentJoined"
+        _ <-
+          liftIO $
+            expectMessages white.player.inbox ["opponentJoined"] black.player.inbox []
         disconnectPlayer white
         disconnectPlayer black
 
-    it "delivers move to opponent" $ withBothPlayers $ \_ white black -> do
-      liftIO $ clientSendMsg black.conn (validMoves !! 0)
-      moveMsg <- liftIO $ expectFrom white.conn black.conn
-      liftIO $ msgType moveMsg `shouldBe` Just "moveMade"
+    it "delivers move to opponent" $ withBothPlayers $ \white black -> do
+      liftIO $ black.send (validMoves !! 0)
+      _ <- liftIO $ expectMessages white.inbox ["moveMade"] black.inbox []
+      pass
 
     it "sends error for invalid move without crashing" $
-      withBothPlayers $ \_ white black -> do
-        liftIO $ clientSendMsg white.conn (validMoves !! 1)
-        errMsg <- liftIO $ expectFrom white.conn black.conn
-        liftIO $ msgType errMsg `shouldBe` Just "error"
-        liftIO $ clientSendMsg black.conn (validMoves !! 0)
-        moveMsg <- liftIO $ expectFrom white.conn black.conn
-        liftIO $ msgType moveMsg `shouldBe` Just "moveMade"
+      withBothPlayers $ \white black -> do
+        liftIO $ white.send (validMoves !! 1)
+        _ <- liftIO $ expectMessages white.inbox ["error"] black.inbox []
+        liftIO $ black.send (validMoves !! 0)
+        _ <- liftIO $ expectMessages white.inbox ["moveMade"] black.inbox []
+        pass
 
     it "resign ends the game and notifies both" $
-      withBothPlayers $ \_ white black -> do
-        liftIO $ clientSendMsg black.conn OnlineResign
-        whiteMsg <- liftIO $ clientRecvJSON white.conn
-        blackMsg <- liftIO $ clientRecvJSON black.conn
-        liftIO $ do
-          msgType whiteMsg `shouldBe` Just "gameOver"
-          msgType blackMsg `shouldBe` Just "gameOver"
+      withBothPlayers $ \white black -> do
+        liftIO $ black.send OnlineResign
+        _ <- liftIO $ expectMessages white.inbox ["gameOver"] black.inbox ["gameOver"]
+        pass
 
     it "disconnect notifies remaining player" $ \connVar -> do
       runOnlineTest connVar $ do
         game <- setupGame
         (white, _) <- connectPlayer game game.result.whiteToken
         (black, _) <- connectPlayer game game.result.blackToken
-        _ <- liftIO $ clientRecvJSON white.conn -- opponentJoined
+        _ <-
+          liftIO $
+            expectMessages white.player.inbox ["opponentJoined"] black.player.inbox []
         disconnectPlayer black
-        msg <- liftIO $ clientRecvJSON white.conn
-        liftIO $ msgType msg `shouldBe` Just "opponentLeft"
+        _ <-
+          liftIO $
+            expectMessages white.player.inbox ["opponentLeft"] black.player.inbox []
         disconnectPlayer white
 
     it "reconnect receives resumed game state with history" $ \connVar -> do
@@ -196,11 +251,17 @@ spec_onlineSession = around withSharedDB $ do
         game <- setupGame
         (white, _) <- connectPlayer game game.result.whiteToken
         (black, _) <- connectPlayer game game.result.blackToken
-        _ <- liftIO $ clientRecvJSON white.conn -- opponentJoined
-        liftIO $ clientSendMsg black.conn (validMoves !! 0)
-        _ <- liftIO $ expectFrom white.conn black.conn -- moveMade
+        _ <-
+          liftIO $
+            expectMessages white.player.inbox ["opponentJoined"] black.player.inbox []
+        liftIO $ black.player.send (validMoves !! 0)
+        _ <-
+          liftIO $
+            expectMessages white.player.inbox ["moveMade"] black.player.inbox []
         disconnectPlayer black
-        _ <- liftIO $ clientRecvJSON white.conn -- opponentLeft
+        _ <-
+          liftIO $
+            expectMessages white.player.inbox ["opponentLeft"] black.player.inbox []
         (black2, gameState) <- connectPlayer game game.result.blackToken
         liftIO $ case gameState of
           Aeson.Object obj ->
@@ -213,13 +274,82 @@ spec_onlineSession = around withSharedDB $ do
         disconnectPlayer black2
 
     it "multiple moves maintain correct turn order" $
-      withBothPlayers $ \_ white black -> do
-        liftIO $ clientSendMsg black.conn (validMoves !! 0)
-        msg1 <- liftIO $ expectFrom white.conn black.conn
-        liftIO $ msgType msg1 `shouldBe` Just "moveMade"
-        liftIO $ clientSendMsg white.conn (validMoves !! 1)
-        msg2 <- liftIO $ expectFrom black.conn white.conn
-        liftIO $ msgType msg2 `shouldBe` Just "moveMade"
-        liftIO $ clientSendMsg black.conn (validMoves !! 2)
-        msg3 <- liftIO $ expectFrom white.conn black.conn
-        liftIO $ msgType msg3 `shouldBe` Just "moveMade"
+      withBothPlayers $ \white black -> do
+        liftIO $ black.send (validMoves !! 0)
+        _ <- liftIO $ expectMessages white.inbox ["moveMade"] black.inbox []
+        liftIO $ white.send (validMoves !! 1)
+        _ <- liftIO $ expectMessages black.inbox ["moveMade"] white.inbox []
+        liftIO $ black.send (validMoves !! 2)
+        _ <- liftIO $ expectMessages white.inbox ["moveMade"] black.inbox []
+        pass
+
+    it "timeout fires and ends timed game" $
+      withBothPlayersTimed $ \clock white black -> do
+        liftIO $ black.send (validMoves !! 0)
+        _ <-
+          liftIO $
+            expectMessages white.inbox ["moveMade"] black.inbox ["clockUpdated"]
+        -- Advance clock past the 1-second timeout
+        STM.atomically $ STM.modifyTVar' clock (add (Timespan 1_200_000_000))
+        _ <-
+          liftIO $
+            expectMessages white.inbox ["gameOver"] black.inbox ["gameOver"]
+        pass
+
+    it "move resets timeout timer" $
+      withBothPlayersTimed $ \clock white black -> do
+        liftIO $ black.send (validMoves !! 0)
+        _ <-
+          liftIO $
+            expectMessages white.inbox ["moveMade"] black.inbox ["clockUpdated"]
+        -- Advance 800ms (not enough to timeout)
+        STM.atomically $ STM.modifyTVar' clock (add (Timespan 800_000_000))
+        liftIO $ white.send (validMoves !! 1)
+        _ <-
+          liftIO $
+            expectMessages black.inbox ["moveMade"] white.inbox ["clockUpdated"]
+        -- Advance another 800ms (1.6s total > 1s, but timer was reset)
+        STM.atomically $ STM.modifyTVar' clock (add (Timespan 800_000_000))
+        liftIO $ black.send (validMoves !! 2)
+        _ <-
+          liftIO $
+            expectMessages white.inbox ["moveMade"] black.inbox ["clockUpdated"]
+        pass
+
+    it "resignation cancels pending timeout" $
+      withBothPlayersTimed $ \clock white black -> do
+        liftIO $ black.send (validMoves !! 0)
+        _ <-
+          liftIO $
+            expectMessages white.inbox ["moveMade"] black.inbox ["clockUpdated"]
+        -- White's clock is ticking. Black resigns before timeout.
+        liftIO $ black.send OnlineResign
+        _ <-
+          liftIO $
+            expectMessages white.inbox ["gameOver"] black.inbox ["gameOver"]
+        -- Advance clock well past what would have been the timeout.
+        -- If timer wasn't cancelled, this would enqueue a stale
+        -- TimeoutFired and cause problems on next queue read.
+        STM.atomically $ STM.modifyTVar' clock (add (Timespan 5_000_000_000))
+        pass
+
+    it "draw offer does not reset timeout" $
+      withBothPlayersTimed $ \clock white black -> do
+        liftIO $ black.send (validMoves !! 0)
+        _ <-
+          liftIO $
+            expectMessages white.inbox ["moveMade"] black.inbox ["clockUpdated"]
+        -- Advance 800ms
+        STM.atomically $ STM.modifyTVar' clock (add (Timespan 800_000_000))
+        -- White offers a draw (no clock change, timer should NOT reset)
+        liftIO $ white.send OnlineOfferDraw
+        _ <-
+          liftIO $
+            expectMessages black.inbox ["drawOffered"] white.inbox []
+        -- Advance another 300ms (total 1.1s > 1s timeout)
+        -- If timer was incorrectly reset on draw offer, this wouldn't timeout
+        STM.atomically $ STM.modifyTVar' clock (add (Timespan 300_000_000))
+        _ <-
+          liftIO $
+            expectMessages white.inbox ["gameOver"] black.inbox ["gameOver"]
+        pass

--- a/backend/test/Hnefatafl/App/OnlineSessionTest.hs
+++ b/backend/test/Hnefatafl/App/OnlineSessionTest.hs
@@ -1,0 +1,225 @@
+module Hnefatafl.App.OnlineSessionTest where
+
+import Data.List ((!!))
+
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Effectful (Eff, IOE, (:>))
+import Effectful.Concurrent (Concurrent)
+import Effectful.Concurrent.Async qualified as Async
+import Effectful.Concurrent.STM qualified as STM
+import Effectful.Katip (KatipE)
+import Hnefatafl.Api.Types (Position (..))
+import Hnefatafl.Api.Types.WS.Online (OnlineClientMessage (..))
+import Hnefatafl.Core.Data (Move (..), MoveResult (..))
+import Hnefatafl.App.Online (CreateGameResult (..), GameSessions)
+import Hnefatafl.App.Online qualified as Online
+import Hnefatafl.App.TestUtil (
+  TestConnPair (..),
+  clientRecvJSON,
+  clientSendAuth,
+  clientSendMsg,
+  expectFrom,
+  mkTestConnPair,
+  runOnlineTest,
+ )
+import Hnefatafl.Core.Data (
+  GameParticipantToken (..),
+ )
+import TestUtil (realMoveResults)
+import Hnefatafl.Effect.Clock (Clock)
+import Hnefatafl.Effect.IdGen (IdGen)
+import Hnefatafl.Effect.Storage (Storage)
+import Hnefatafl.Effect.Trace (Trace)
+import Hnefatafl.Effect.WebSocket (WebSocket)
+import Database.SQLite.Simple (Connection)
+import Hnefatafl.Interpreter.Storage.SQLite.Util (withSharedDB)
+import Hnefatafl.Metrics (HMetrics)
+import StmContainers.Map qualified as STMMap
+import Test.Hspec (Spec, around, describe, it, shouldBe)
+
+-------------------------------------------------------------------------------
+-- Move fixtures from a known valid game. Alternates black/white.
+
+validMoves :: [OnlineClientMessage]
+validMoves =
+  map
+    (\mr -> OnlineMove (Position $ fromIntegral mr.move.orig) (Position $ fromIntegral mr.move.dest))
+    (toList realMoveResults)
+
+-------------------------------------------------------------------------------
+-- Helpers
+
+msgType :: Aeson.Value -> Maybe Text
+msgType (Aeson.Object obj) =
+  case KeyMap.lookup "type" obj of
+    Just (Aeson.String t) -> Just t
+    _ -> Nothing
+msgType _ = Nothing
+
+msgField :: Text -> Aeson.Value -> Maybe Text
+msgField key (Aeson.Object obj) =
+  case KeyMap.lookup (Key.fromText key) obj of
+    Just (Aeson.String t) -> Just t
+    _ -> Nothing
+msgField _ _ = Nothing
+
+type TestEff es =
+  ( Storage :> es
+  , Clock :> es
+  , IdGen :> es
+  , Concurrent :> es
+  , WebSocket :> es
+  , KatipE :> es
+  , Trace :> es
+  , HMetrics :> es
+  , IOE :> es
+  )
+
+data TestGame = TestGame
+  { sessions :: GameSessions
+  , result :: CreateGameResult
+  }
+
+-- | Create a game with a shared session map.
+setupGame :: TestEff es => Eff es TestGame
+setupGame = do
+  sessions <- STM.atomically STMMap.new
+  result <- Online.createGame Nothing
+  pure TestGame{sessions, result}
+
+data ConnectedPlayer = ConnectedPlayer
+  { conn :: TestConnPair
+  , wsThread :: Async.Async ()
+  }
+
+-- | Connect a player via the full handleWebSocket path.
+-- Authenticates and returns after receiving the initial game state.
+connectPlayer ::
+  TestEff es =>
+  TestGame ->
+  GameParticipantToken ->
+  Eff es (ConnectedPlayer, Aeson.Value)
+connectPlayer game token = do
+  tc <- liftIO mkTestConnPair
+  wsThread <- Async.async $
+    Online.handleWebSocket game.sessions tc.connection
+  liftIO $ clientSendAuth tc token.token
+  initialState <- liftIO $ clientRecvJSON tc
+  pure (ConnectedPlayer{conn = tc, wsThread}, initialState)
+
+disconnectPlayer :: Concurrent :> es => ConnectedPlayer -> Eff es ()
+disconnectPlayer = Async.cancel . (.wsThread)
+
+-- | Connect both players, drain the opponentJoined notification,
+-- run an action, then disconnect both. The action receives the
+-- game setup and both players with clean message queues.
+withBothPlayers ::
+  ( forall es.
+    TestEff es =>
+    TestGame -> ConnectedPlayer -> ConnectedPlayer -> Eff es ()
+  ) ->
+  MVar Connection ->
+  IO ()
+withBothPlayers action connVar =
+  runOnlineTest connVar $ do
+    game <- setupGame
+    (white, _) <- connectPlayer game game.result.whiteToken
+    (black, _) <- connectPlayer game game.result.blackToken
+    _ <- liftIO $ clientRecvJSON white.conn -- opponentJoined
+    action game white black
+    disconnectPlayer white
+    disconnectPlayer black
+
+-------------------------------------------------------------------------------
+-- Tests
+
+spec_onlineSession :: Spec
+spec_onlineSession = around withSharedDB $ do
+  describe "online session" $ do
+    it "sends game state on connect" $ \connVar -> do
+      runOnlineTest connVar $ do
+        game <- setupGame
+        (player, gameState) <- connectPlayer game game.result.whiteToken
+        liftIO $ do
+          msgType gameState `shouldBe` Just "gameState"
+          msgField "playerColor" gameState `shouldBe` Just "white"
+        disconnectPlayer player
+
+    it "notifies first player when second connects" $ \connVar -> do
+      runOnlineTest connVar $ do
+        game <- setupGame
+        (white, _) <- connectPlayer game game.result.whiteToken
+        (black, _) <- connectPlayer game game.result.blackToken
+        msg <- liftIO $ clientRecvJSON white.conn
+        liftIO $ msgType msg `shouldBe` Just "opponentJoined"
+        disconnectPlayer white
+        disconnectPlayer black
+
+    it "delivers move to opponent" $ withBothPlayers $ \_ white black -> do
+      liftIO $ clientSendMsg black.conn (validMoves !! 0)
+      moveMsg <- liftIO $ expectFrom white.conn black.conn
+      liftIO $ msgType moveMsg `shouldBe` Just "moveMade"
+
+    it "sends error for invalid move without crashing" $
+      withBothPlayers $ \_ white black -> do
+        liftIO $ clientSendMsg white.conn (validMoves !! 1)
+        errMsg <- liftIO $ expectFrom white.conn black.conn
+        liftIO $ msgType errMsg `shouldBe` Just "error"
+        liftIO $ clientSendMsg black.conn (validMoves !! 0)
+        moveMsg <- liftIO $ expectFrom white.conn black.conn
+        liftIO $ msgType moveMsg `shouldBe` Just "moveMade"
+
+    it "resign ends the game and notifies both" $
+      withBothPlayers $ \_ white black -> do
+        liftIO $ clientSendMsg black.conn OnlineResign
+        whiteMsg <- liftIO $ clientRecvJSON white.conn
+        blackMsg <- liftIO $ clientRecvJSON black.conn
+        liftIO $ do
+          msgType whiteMsg `shouldBe` Just "gameOver"
+          msgType blackMsg `shouldBe` Just "gameOver"
+
+    it "disconnect notifies remaining player" $ \connVar -> do
+      runOnlineTest connVar $ do
+        game <- setupGame
+        (white, _) <- connectPlayer game game.result.whiteToken
+        (black, _) <- connectPlayer game game.result.blackToken
+        _ <- liftIO $ clientRecvJSON white.conn -- opponentJoined
+        disconnectPlayer black
+        msg <- liftIO $ clientRecvJSON white.conn
+        liftIO $ msgType msg `shouldBe` Just "opponentLeft"
+        disconnectPlayer white
+
+    it "reconnect receives resumed game state with history" $ \connVar -> do
+      runOnlineTest connVar $ do
+        game <- setupGame
+        (white, _) <- connectPlayer game game.result.whiteToken
+        (black, _) <- connectPlayer game game.result.blackToken
+        _ <- liftIO $ clientRecvJSON white.conn -- opponentJoined
+        liftIO $ clientSendMsg black.conn (validMoves !! 0)
+        _ <- liftIO $ expectFrom white.conn black.conn -- moveMade
+        disconnectPlayer black
+        _ <- liftIO $ clientRecvJSON white.conn -- opponentLeft
+        (black2, gameState) <- connectPlayer game game.result.blackToken
+        liftIO $ case gameState of
+          Aeson.Object obj ->
+            case KeyMap.lookup "history" obj of
+              Just (Aeson.Array arr) ->
+                length arr `shouldBe` 1
+              other -> fail $ "Expected history array, got " <> show other
+          other -> fail $ "Expected object, got " <> show other
+        disconnectPlayer white
+        disconnectPlayer black2
+
+    it "multiple moves maintain correct turn order" $
+      withBothPlayers $ \_ white black -> do
+        liftIO $ clientSendMsg black.conn (validMoves !! 0)
+        msg1 <- liftIO $ expectFrom white.conn black.conn
+        liftIO $ msgType msg1 `shouldBe` Just "moveMade"
+        liftIO $ clientSendMsg white.conn (validMoves !! 1)
+        msg2 <- liftIO $ expectFrom black.conn white.conn
+        liftIO $ msgType msg2 `shouldBe` Just "moveMade"
+        liftIO $ clientSendMsg black.conn (validMoves !! 2)
+        msg3 <- liftIO $ expectFrom white.conn black.conn
+        liftIO $ msgType msg3 `shouldBe` Just "moveMade"

--- a/backend/test/Hnefatafl/App/OnlineSessionTest.hs
+++ b/backend/test/Hnefatafl/App/OnlineSessionTest.hs
@@ -297,6 +297,19 @@ spec_onlineSession = around withSharedDB $ do
             expectMessages white.inbox ["gameOver"] black.inbox ["gameOver"]
         pass
 
+    it "no timeout before the first move" $
+      withBothPlayersTimed $ \clock white black -> do
+        -- Advance well past the 1-second initial time before anyone
+        -- moves. The clock has not started, so nobody should flag.
+        STM.atomically $ STM.modifyTVar' clock (add (Timespan 3_000_000_000))
+        -- Black's opening move still succeeds: had a timeout fired,
+        -- the game would be finished and the move rejected.
+        sendMsg black (validMoves !! 0)
+        _ <-
+          liftIO $
+            expectMessages white.inbox ["moveMade"] black.inbox ["clockUpdated"]
+        pass
+
     it "move resets timeout timer" $
       withBothPlayersTimed $ \clock white black -> do
         sendMsg black (validMoves !! 0)

--- a/backend/test/Hnefatafl/App/TestUtil.hs
+++ b/backend/test/Hnefatafl/App/TestUtil.hs
@@ -9,6 +9,7 @@ module Hnefatafl.App.TestUtil (
   clientSendAuth,
   clientRecv,
   clientRecvJSON,
+  expectFrom,
 
   -- * Effect stack runners
   runHotseatTest,
@@ -19,6 +20,7 @@ import Control.Concurrent.MVar qualified as MVar
 import Control.Concurrent.STM (
   TQueue,
   newTQueueIO,
+  orElse,
   readTQueue,
   writeTQueue,
  )
@@ -33,22 +35,23 @@ import Hnefatafl.App.WebSocket (encodeAuthMsg)
 import Hnefatafl.Effect.Clock (Clock)
 import Hnefatafl.Effect.IdGen (IdGen)
 import Hnefatafl.Effect.Storage (Storage)
-import Hnefatafl.Metrics (HMetrics)
 import Hnefatafl.Effect.Trace (Trace)
 import Hnefatafl.Effect.WebSocket (WebSocket)
 import Hnefatafl.Interpreter.Clock.IO (runClockIO)
 import Hnefatafl.Interpreter.IdGen.UUIDv7 (runIdGenUUIDv7)
-import Hnefatafl.Interpreter.Storage.SQLite (runStorageSQLite)
 import Hnefatafl.Interpreter.Metrics.NoOp (runMetricsNoOp)
+import Hnefatafl.Interpreter.Storage.SQLite (runStorageSQLite)
 import Hnefatafl.Interpreter.Trace.NoOp (runTraceNoOp)
 import Hnefatafl.Interpreter.WebSocket.IO (runWebSocketIO)
 import Hnefatafl.Logging (withNoLogEnv)
+import Hnefatafl.Metrics (HMetrics)
 import Network.WebSockets (
   DataMessage (..),
   Message (..),
   defaultConnectionOptions,
  )
 import Network.WebSockets.Connection (Connection (..))
+import System.Timeout (timeout)
 import Unsafe.Coerce (unsafeCoerce)
 
 -------------------------------------------------------------------------------
@@ -111,6 +114,30 @@ clientRecvJSON tc = do
     Just v -> pure v
     Nothing -> error $ "clientRecvJSON: failed to decode: " <> show bs
 
+-- | Read a message expected on one socket, failing if it arrives on
+-- the other instead. Uses STM 'orElse' to check both without
+-- polling. A 2-second timeout catches bugs where no message arrives
+-- at all.
+expectFrom :: TestConnPair -> TestConnPair -> IO Aeson.Value
+expectFrom expected unexpected = do
+  let readExpected = Left <$> readTQueue expected.serverToClient
+      readUnexpected = Right <$> readTQueue unexpected.serverToClient
+  result <- timeout 2_000_000 $ atomically (readExpected `orElse` readUnexpected)
+  case result of
+    Nothing ->
+      error "expectFrom: timed out waiting for message on either socket"
+    Just (Left msg) -> case msg of
+      DataMessage _ _ _ (Text bs _) ->
+        case Aeson.decode bs of
+          Just v -> pure v
+          Nothing -> error $ "expectFrom: failed to decode: " <> show bs
+      other -> error $ "expectFrom: unexpected message type: " <> show other
+    Just (Right msg) -> case msg of
+      DataMessage _ _ _ (Text bs _) ->
+        error $ "expectFrom: message arrived on wrong socket: " <> show bs
+      other ->
+        error $ "expectFrom: unexpected message on wrong socket: " <> show other
+
 -------------------------------------------------------------------------------
 -- Effect stack runners
 
@@ -146,11 +173,11 @@ runHotseatTest connVar action = do
   case result of
     Left err -> error $ toText $ "runHotseatTest: " <> err
     Right a -> pure a
-  where
-    unusedOpenConn =
-      error
-        "runHotseatTest: connection-replacement openConn invoked \
-        \unexpectedly (a transaction raised ConnectionUnrecoverableException)"
+ where
+  unusedOpenConn =
+    error
+      "runHotseatTest: connection-replacement openConn invoked \
+      \unexpectedly (a transaction raised ConnectionUnrecoverableException)"
 
 -- | Run an online/AI test with Storage, Clock, IdGen, Concurrent, WebSocket,
 -- and KatipE effects. Logs are silently dropped via withNoLogEnv.
@@ -186,8 +213,8 @@ runOnlineTest connVar action = do
   case result of
     Left err -> error $ toText $ "runOnlineTest: " <> err
     Right a -> pure a
-  where
-    unusedOpenConn =
-      error
-        "runOnlineTest: connection-replacement openConn invoked \
-        \unexpectedly (a transaction raised ConnectionUnrecoverableException)"
+ where
+  unusedOpenConn =
+    error
+      "runOnlineTest: connection-replacement openConn invoked \
+      \unexpectedly (a transaction raised ConnectionUnrecoverableException)"

--- a/backend/test/Hnefatafl/App/TestUtil.hs
+++ b/backend/test/Hnefatafl/App/TestUtil.hs
@@ -128,8 +128,9 @@ newtype Inbox = Inbox (TQueue Message)
 -- orElse; when a message arrives it must match the next expected
 -- type for that inbox. Fails immediately on mismatch or if the
 -- 100ms safety timeout expires.
-expectMessages :: Inbox -> [Text] -> Inbox -> [Text] -> IO [Aeson.Value]
-expectMessages (Inbox q1) expected1 (Inbox q2) expected2 = do
+expectMessages ::
+  MonadIO m => Inbox -> [Text] -> Inbox -> [Text] -> m [Aeson.Value]
+expectMessages (Inbox q1) expected1 (Inbox q2) expected2 = liftIO $ do
   raw <- replicateM (length expected1 + length expected2) readOne
   let (from1, from2) = partitionEithers raw
   checkTypes "inbox1" expected1 from1

--- a/backend/test/Hnefatafl/App/TestUtil.hs
+++ b/backend/test/Hnefatafl/App/TestUtil.hs
@@ -3,19 +3,22 @@
 module Hnefatafl.App.TestUtil (
   -- * Test WebSocket connections
   TestConnPair (..),
+  Inbox (..),
   mkTestConnPair,
   clientSend,
   clientSendMsg,
   clientSendAuth,
   clientRecv,
   clientRecvJSON,
-  expectFrom,
+  expectMessages,
 
   -- * Effect stack runners
   runHotseatTest,
   runOnlineTest,
+  runOnlineTestTimed,
 ) where
 
+import Chronos (Time (..))
 import Control.Concurrent.MVar qualified as MVar
 import Control.Concurrent.STM (
   TQueue,
@@ -26,9 +29,11 @@ import Control.Concurrent.STM (
  )
 import Data.Aeson (ToJSON, encode)
 import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KeyMap
 import Database.SQLite.Simple (Connection)
 import Effectful
 import Effectful.Concurrent (Concurrent, runConcurrent)
+import Effectful.Concurrent.STM qualified as STM
 import Effectful.Error.Static (runErrorNoCallStack)
 import Effectful.Katip (KatipE, runKatipE)
 import Hnefatafl.App.WebSocket (encodeAuthMsg)
@@ -38,6 +43,7 @@ import Hnefatafl.Effect.Storage (Storage)
 import Hnefatafl.Effect.Trace (Trace)
 import Hnefatafl.Effect.WebSocket (WebSocket)
 import Hnefatafl.Interpreter.Clock.IO (runClockIO)
+import Hnefatafl.Interpreter.Clock.Test (runClockTest)
 import Hnefatafl.Interpreter.IdGen.UUIDv7 (runIdGenUUIDv7)
 import Hnefatafl.Interpreter.Metrics.NoOp (runMetricsNoOp)
 import Hnefatafl.Interpreter.Storage.SQLite (runStorageSQLite)
@@ -114,29 +120,53 @@ clientRecvJSON tc = do
     Just v -> pure v
     Nothing -> error $ "clientRecvJSON: failed to decode: " <> show bs
 
--- | Read a message expected on one socket, failing if it arrives on
--- the other instead. Uses STM 'orElse' to check both without
--- polling. A 2-second timeout catches bugs where no message arrives
--- at all.
-expectFrom :: TestConnPair -> TestConnPair -> IO Aeson.Value
-expectFrom expected unexpected = do
-  let readExpected = Left <$> readTQueue expected.serverToClient
-      readUnexpected = Right <$> readTQueue unexpected.serverToClient
-  result <- timeout 2_000_000 $ atomically (readExpected `orElse` readUnexpected)
-  case result of
-    Nothing ->
-      error "expectFrom: timed out waiting for message on either socket"
-    Just (Left msg) -> case msg of
-      DataMessage _ _ _ (Text bs _) ->
-        case Aeson.decode bs of
-          Just v -> pure v
-          Nothing -> error $ "expectFrom: failed to decode: " <> show bs
-      other -> error $ "expectFrom: unexpected message type: " <> show other
-    Just (Right msg) -> case msg of
-      DataMessage _ _ _ (Text bs _) ->
-        error $ "expectFrom: message arrived on wrong socket: " <> show bs
-      other ->
-        error $ "expectFrom: unexpected message on wrong socket: " <> show other
+-- | The receive side of a test WebSocket connection.
+newtype Inbox = Inbox (TQueue Message)
+
+-- | Expect specific messages on two inboxes. Each inbox has an
+-- ordered list of expected message types. Reads from both via STM
+-- orElse; when a message arrives it must match the next expected
+-- type for that inbox. Fails immediately on mismatch or if the
+-- 100ms safety timeout expires.
+expectMessages :: Inbox -> [Text] -> Inbox -> [Text] -> IO [Aeson.Value]
+expectMessages (Inbox q1) expected1 (Inbox q2) expected2 = do
+  raw <- replicateM (length expected1 + length expected2) readOne
+  let (from1, from2) = partitionEithers raw
+  checkTypes "inbox1" expected1 from1
+  checkTypes "inbox2" expected2 from2
+  pure (from1 <> from2)
+ where
+  readOne = do
+    result <-
+      timeout 100_000 $
+        atomically ((Left <$> readTQueue q1) `orElse` (Right <$> readTQueue q2))
+    case result of
+      Nothing -> error "expectMessages: timed out waiting for message"
+      Just (Left msg) -> Left <$> decodeMsg "inbox1" msg
+      Just (Right msg) -> Right <$> decodeMsg "inbox2" msg
+  decodeMsg label (DataMessage _ _ _ (Text bs _)) = case Aeson.decode bs of
+    Just v -> pure v
+    Nothing -> error $ "expectMessages: failed to decode on " <> label
+  decodeMsg label _ =
+    error $ "expectMessages: unexpected ws frame on " <> label
+  checkTypes label expected actual =
+    zipWithM_ check expected actual
+   where
+    check e v
+      | msgTypeOf v == e = pure ()
+      | otherwise =
+          error $
+            "expectMessages: "
+              <> label
+              <> " got '"
+              <> msgTypeOf v
+              <> "' but expected '"
+              <> e
+              <> "'"
+  msgTypeOf (Aeson.Object obj) = case KeyMap.lookup "type" obj of
+    Just (Aeson.String t) -> t
+    _ -> error "expectMessages: message has no 'type' field"
+  msgTypeOf _ = error "expectMessages: message is not a JSON object"
 
 -------------------------------------------------------------------------------
 -- Effect stack runners
@@ -217,4 +247,47 @@ runOnlineTest connVar action = do
   unusedOpenConn =
     error
       "runOnlineTest: connection-replacement openConn invoked \
+      \unexpectedly (a transaction raised ConnectionUnrecoverableException)"
+
+-- | Like runOnlineTest but with a controllable test clock.
+-- Returns the TVar so tests can advance time.
+runOnlineTestTimed ::
+  MVar Database.SQLite.Simple.Connection ->
+  ( forall es.
+    ( IOE :> es
+    , Storage :> es
+    , Clock :> es
+    , IdGen :> es
+    , Concurrent :> es
+    , WebSocket :> es
+    , KatipE :> es
+    , Trace :> es
+    , HMetrics :> es
+    ) =>
+    TVar Time ->
+    Eff es a
+  ) ->
+  IO a
+runOnlineTestTimed connVar action = do
+  result <- withNoLogEnv "test" $ \logEnv ->
+    runEff
+      . runErrorNoCallStack @String
+      . runKatipE logEnv
+      . runTraceNoOp
+      . runMetricsNoOp
+      . runConcurrent
+      $ do
+        timeVar <- STM.atomically $ STM.newTVar (Time 0)
+        runClockTest timeVar
+          . runStorageSQLite connVar unusedOpenConn
+          . runIdGenUUIDv7
+          . runWebSocketIO
+          $ action timeVar
+  case result of
+    Left err -> error $ toText $ "runOnlineTestTimed: " <> err
+    Right a -> pure a
+ where
+  unusedOpenConn =
+    error
+      "runOnlineTestTimed: connection-replacement openConn invoked \
       \unexpectedly (a transaction raised ConnectionUnrecoverableException)"

--- a/backend/test/Hnefatafl/Core/DataTest.hs
+++ b/backend/test/Hnefatafl/Core/DataTest.hs
@@ -1,0 +1,51 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Hnefatafl.Core.DataTest where
+
+import Data.Aeson (eitherDecode, encode)
+import Hnefatafl.Core.Data (Seconds (..), TimeControl (..))
+import Refined (unrefine)
+import Refined.Unsafe (reallyUnsafeRefine)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+spec_timeControlParsing :: Spec
+spec_timeControlParsing =
+  describe "TimeControl JSON parsing" $ do
+    it "parses valid time control" $ do
+      let json = "{\"initialTime\": 300, \"increment\": 5}"
+          result = eitherDecode json :: Either String TimeControl
+      result `shouldSatisfy` isRight
+      let Right tc = result
+      unrefine tc.initialTime `shouldBe` Seconds 300
+      unrefine tc.increment `shouldBe` Seconds 5
+
+    it "accepts zero increment" $ do
+      let json = "{\"initialTime\": 300, \"increment\": 0}"
+          result = eitherDecode json :: Either String TimeControl
+      result `shouldSatisfy` isRight
+      let Right tc = result
+      unrefine tc.increment `shouldBe` Seconds 0
+
+    it "rejects negative initialTime" $ do
+      let json = "{\"initialTime\": -1, \"increment\": 5}"
+          result = eitherDecode json :: Either String TimeControl
+      result `shouldSatisfy` isLeft
+
+    it "rejects zero initialTime" $ do
+      let json = "{\"initialTime\": 0, \"increment\": 5}"
+          result = eitherDecode json :: Either String TimeControl
+      result `shouldSatisfy` isLeft
+
+    it "rejects negative increment" $ do
+      let json = "{\"initialTime\": 300, \"increment\": -1}"
+          result = eitherDecode json :: Either String TimeControl
+      result `shouldSatisfy` isLeft
+
+    it "round-trips through JSON" $ do
+      let tc =
+            TimeControl
+              (reallyUnsafeRefine (Seconds 600))
+              (reallyUnsafeRefine (Seconds 10))
+          json = encode tc
+          result = eitherDecode json :: Either String TimeControl
+      result `shouldBe` Right tc

--- a/backend/test/Hnefatafl/Game/ClockTest.hs
+++ b/backend/test/Hnefatafl/Game/ClockTest.hs
@@ -1,11 +1,24 @@
 module Hnefatafl.Game.ClockTest where
 
 import Chronos (Time (..))
-import Hnefatafl.Core.Data (ClockState (..), PlayerColor (..))
-import Hnefatafl.Game.Online (updateClock)
+import Hnefatafl.Bindings (startBlackMoves, startBoard)
+import Hnefatafl.Core.Data (
+  ClockState (..),
+  MoveWithCaptures (..),
+  PlayerColor (..),
+ )
+import Hnefatafl.Game.Online (
+  Event (..),
+  Phase (..),
+  State (..),
+  TransitionResult (..),
+  transition,
+  updateClock,
+ )
 import Hnefatafl.Game.TestUtil (mkRemaining, mkTC, remainingSec)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
+import Prelude hiding (State)
 
 test_updateClock :: TestTree
 test_updateClock =
@@ -56,4 +69,62 @@ test_updateClock =
         case updateClock (mkTC 300 0) cs Black (Time 0) of
           Just cs' -> remainingSec cs'.blackRemaining @?= 300
           Nothing -> fail "expected Just"
+    ]
+
+-- | A timed game just before its first move: Black to move, both
+-- clocks full, turnStartedAt unset (epoch).
+timedInitial :: State
+timedInitial =
+  let cs = ClockState (mkRemaining 300) (mkRemaining 300) (Time 0)
+   in State
+        startBoard
+        []
+        (Active Black (toList startBlackMoves) Nothing (Just (mkTC 300 0, cs)))
+
+clockOf :: State -> Maybe ClockState
+clockOf (State _ _ (Active _ _ _ clk)) = snd <$> clk
+clockOf _ = Nothing
+
+test_firstMoveClock :: TestTree
+test_firstMoveClock =
+  testGroup
+    "first move clock"
+    [ testCase "first move deducts from neither clock" $
+        case toList startBlackMoves of
+          (vm : _) ->
+            case transition timedInitial (MakeMove Black vm.move (Time 2_000_000_000)) of
+              Right (TransitionResult ns _) -> case clockOf ns of
+                Just cs' -> do
+                  remainingSec cs'.blackRemaining @?= 300
+                  remainingSec cs'.whiteRemaining @?= 300
+                Nothing -> fail "expected a clock on the resulting state"
+              Left e -> fail $ "unexpected transition error: " <> show e
+          [] -> fail "no opening moves for Black"
+    , testCase "first move sets turnStartedAt to the move time" $
+        case toList startBlackMoves of
+          (vm : _) ->
+            case transition timedInitial (MakeMove Black vm.move (Time 2_000_000_000)) of
+              Right (TransitionResult ns _) -> case clockOf ns of
+                Just cs' -> cs'.turnStartedAt @?= Time 2_000_000_000
+                Nothing -> fail "expected a clock on the resulting state"
+              Left e -> fail $ "unexpected transition error: " <> show e
+          [] -> fail "no opening moves for Black"
+    , testCase "second move deducts elapsed from the mover" $
+        case toList startBlackMoves of
+          (bvm : _) ->
+            -- Black opens at t=1s (free); White replies at t=3s, so 2s
+            -- is deducted from White's clock.
+            case transition timedInitial (MakeMove Black bvm.move (Time 1_000_000_000)) of
+              Right (TransitionResult afterBlack _) -> case afterBlack of
+                State _ _ (Active White (wvm : _) _ _) ->
+                  case transition afterBlack (MakeMove White wvm.move (Time 3_000_000_000)) of
+                    Right (TransitionResult afterWhite _) -> case clockOf afterWhite of
+                      Just cs' -> do
+                        remainingSec cs'.whiteRemaining @?= 298
+                        remainingSec cs'.blackRemaining @?= 300
+                      Nothing -> fail "expected a clock on the resulting state"
+                    Left e -> fail $ "White move failed: " <> show e
+                _ -> fail "expected White to move with legal moves"
+              Left e -> fail $ "Black move failed: " <> show e
+          [] -> fail "no opening moves for Black"
     ]

--- a/backend/test/Hnefatafl/Game/ClockTest.hs
+++ b/backend/test/Hnefatafl/Game/ClockTest.hs
@@ -1,0 +1,59 @@
+module Hnefatafl.Game.ClockTest where
+
+import Chronos (Time (..))
+import Hnefatafl.Core.Data (ClockState (..), PlayerColor (..))
+import Hnefatafl.Game.Online (updateClock)
+import Hnefatafl.Game.TestUtil (mkRemaining, mkTC, remainingSec)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+
+test_updateClock :: TestTree
+test_updateClock =
+  testGroup
+    "updateClock"
+    [ testCase "deducts elapsed time from Black" $ do
+        let cs = ClockState (mkRemaining 300) (mkRemaining 300) (Time 0)
+        case updateClock (mkTC 300 0) cs Black (Time 2_000_000_000) of
+          Just cs' -> remainingSec cs'.blackRemaining @?= 298
+          Nothing -> fail "expected Just"
+    , testCase "deducts elapsed time from White" $ do
+        let cs = ClockState (mkRemaining 300) (mkRemaining 300) (Time 0)
+        case updateClock (mkTC 300 0) cs White (Time 2_000_000_000) of
+          Just cs' -> remainingSec cs'.whiteRemaining @?= 298
+          Nothing -> fail "expected Just"
+    , testCase "adds increment after deduction" $ do
+        let cs = ClockState (mkRemaining 300) (mkRemaining 300) (Time 0)
+        case updateClock (mkTC 300 5) cs Black (Time 2_000_000_000) of
+          Just cs' -> remainingSec cs'.blackRemaining @?= 303
+          Nothing -> fail "expected Just"
+    , testCase "updates turnStartedAt to move time" $ do
+        let cs = ClockState (mkRemaining 300) (mkRemaining 300) (Time 0)
+            moveTime = Time 5_000_000_000
+        case updateClock (mkTC 300 0) cs White moveTime of
+          Just cs' -> cs'.turnStartedAt @?= moveTime
+          Nothing -> fail "expected Just"
+    , testCase "does not affect opponent clock" $ do
+        let cs = ClockState (mkRemaining 300) (mkRemaining 250) (Time 0)
+        case updateClock (mkTC 300 5) cs Black (Time 2_000_000_000) of
+          Just cs' -> remainingSec cs'.whiteRemaining @?= 300
+          Nothing -> fail "expected Just"
+    , testCase "returns Nothing when time expired" $ do
+        let cs = ClockState (mkRemaining 300) (mkRemaining 300) (Time 0)
+        updateClock (mkTC 300 0) cs Black (Time 301_000_000_000)
+          @?= Nothing
+    , testCase "exact remaining succeeds with zero left" $ do
+        let cs = ClockState (mkRemaining 300) (mkRemaining 300) (Time 0)
+        case updateClock (mkTC 300 0) cs Black (Time 300_000_000_000) of
+          Just cs' -> remainingSec cs'.blackRemaining @?= 0
+          Nothing -> fail "expected Just"
+    , testCase "zero elapsed produces no change" $ do
+        let cs = ClockState (mkRemaining 300) (mkRemaining 300) (Time 0)
+        case updateClock (mkTC 300 0) cs Black (Time 0) of
+          Just cs' -> remainingSec cs'.blackRemaining @?= 300
+          Nothing -> fail "expected Just"
+    , testCase "negative elapsed (clock skew) treated as zero" $ do
+        let cs = ClockState (mkRemaining 300) (mkRemaining 300) (Time 5_000_000_000)
+        case updateClock (mkTC 300 0) cs Black (Time 0) of
+          Just cs' -> remainingSec cs'.blackRemaining @?= 300
+          Nothing -> fail "expected Just"
+    ]

--- a/backend/test/Hnefatafl/Game/ClockTest.hs
+++ b/backend/test/Hnefatafl/Game/ClockTest.hs
@@ -9,6 +9,7 @@ import Hnefatafl.Core.Data (
  )
 import Hnefatafl.Game.Online (
   Event (..),
+  GameClock (..),
   Phase (..),
   State (..),
   TransitionResult (..),
@@ -79,11 +80,12 @@ timedInitial =
    in State
         startBoard
         []
-        (Active Black (toList startBlackMoves) Nothing (Just (mkTC 300 0, cs)))
+        (Active Black (toList startBlackMoves) Nothing)
+        (Timed (mkTC 300 0) cs)
 
 clockOf :: State -> Maybe ClockState
-clockOf (State _ _ (Active _ _ _ clk)) = snd <$> clk
-clockOf _ = Nothing
+clockOf (State _ _ _ (Timed _ cs)) = Just cs
+clockOf (State _ _ _ Untimed) = Nothing
 
 test_firstMoveClock :: TestTree
 test_firstMoveClock =
@@ -116,7 +118,7 @@ test_firstMoveClock =
             -- is deducted from White's clock.
             case transition timedInitial (MakeMove Black bvm.move (Time 1_000_000_000)) of
               Right (TransitionResult afterBlack _) -> case afterBlack of
-                State _ _ (Active White (wvm : _) _ _) ->
+                State _ _ (Active White (wvm : _) _) _ ->
                   case transition afterBlack (MakeMove White wvm.move (Time 3_000_000_000)) of
                     Right (TransitionResult afterWhite _) -> case clockOf afterWhite of
                       Just cs' -> do

--- a/backend/test/Hnefatafl/Game/OnlineTest.hs
+++ b/backend/test/Hnefatafl/Game/OnlineTest.hs
@@ -2,7 +2,11 @@ module Hnefatafl.Game.OnlineTest where
 
 import Chronos (Time (..))
 import Hnefatafl.Bindings (startBlackMoves, startBoard)
-import Hnefatafl.Core.Data (MoveWithCaptures (..), Outcome (..), PlayerColor (..))
+import Hnefatafl.Core.Data (
+  MoveWithCaptures (..),
+  Outcome (..),
+  PlayerColor (..),
+ )
 import Hnefatafl.Game.Common (
   AppliedMove (..),
   DomainEvent (..),
@@ -39,16 +43,17 @@ fromStore store =
     store.storedMoves
     store.storedOutcome
     store.storedPendingAction
+    Nothing
 
 mkActiveState :: PlayerColor -> [AppliedMove] -> Maybe PendingAction -> State
 mkActiveState turn moves pending =
   let board = currentBoard moves
       validMoves = validMovesForPosition moves
-   in State board moves (Active turn validMoves pending)
+   in State board moves (Active turn validMoves pending Nothing)
 
 genEvent :: State -> Maybe (Gen Event)
 genEvent (State _ _ (Finished _)) = Nothing
-genEvent (State _ moves (Active turn validMoves pending)) =
+genEvent (State _ moves (Active turn validMoves pending _)) =
   Just $
     frequency $
       concat
@@ -67,7 +72,7 @@ genEvent (State _ moves (Active turn validMoves pending)) =
           , pa.actionType == DrawOffer
           ]
         , [(1, RequestUndo <$> elements [Black, White]) | isNothing pending]
-        , [ (1, pure $ AcceptUndo (opponent pa.offeredBy))
+        , [ (1, pure $ AcceptUndo (opponent pa.offeredBy) (Time 0))
           | Just pa <- [pending]
           , pa.actionType == UndoRequest
           , hasEnoughMoves
@@ -86,7 +91,7 @@ genEvent (State _ moves (Active turn validMoves pending)) =
 
 initialState :: State
 initialState =
-  State startBoard [] (Active Black (toList startBlackMoves) Nothing)
+  State startBoard [] (Active Black (toList startBlackMoves) Nothing Nothing)
 
 genSequence :: State -> Gen [(Event, TransitionResult)]
 genSequence s = case genEvent s of
@@ -125,7 +130,7 @@ test_onlineCancellation =
             move = (head startBlackMoves).move
         case transition st (MakeMove Black move (Time 0)) of
           Right tr -> case tr.newState of
-            State _ _ (Active _ _ p) -> p @?= Nothing
+            State _ _ (Active _ _ p _) -> p @?= Nothing
             other -> fail $ "Expected Active, got " <> show other
           Left e -> fail $ "Expected Right, got Left " <> show e
     , testCase "Move preserves own draw offer" $ do
@@ -133,7 +138,7 @@ test_onlineCancellation =
             move = (head startBlackMoves).move
         case transition st (MakeMove Black move (Time 0)) of
           Right tr -> case tr.newState of
-            State _ _ (Active _ _ p) -> p @?= Just (PendingAction DrawOffer Black)
+            State _ _ (Active _ _ p _) -> p @?= Just (PendingAction DrawOffer Black)
             other -> fail $ "Expected Active, got " <> show other
           Left e -> fail $ "Expected Right, got Left " <> show e
     , testCase "Move cancels opponent's undo request" $ do
@@ -141,7 +146,7 @@ test_onlineCancellation =
             move = (head startBlackMoves).move
         case transition st (MakeMove Black move (Time 0)) of
           Right tr -> case tr.newState of
-            State _ _ (Active _ _ p) -> p @?= Nothing
+            State _ _ (Active _ _ p _) -> p @?= Nothing
             other -> fail $ "Expected Active, got " <> show other
           Left e -> fail $ "Expected Right, got Left " <> show e
     , testCase "Move preserves own undo request" $ do
@@ -149,7 +154,7 @@ test_onlineCancellation =
             move = (head startBlackMoves).move
         case transition st (MakeMove Black move (Time 0)) of
           Right tr -> case tr.newState of
-            State _ _ (Active _ _ p) -> p @?= Just (PendingAction UndoRequest Black)
+            State _ _ (Active _ _ p _) -> p @?= Just (PendingAction UndoRequest Black)
             other -> fail $ "Expected Active, got " <> show other
           Left e -> fail $ "Expected Right, got Left " <> show e
     ]
@@ -171,10 +176,11 @@ test_onlineUndoCount =
                         White
                         (validMovesForPosition moves1)
                         (Just $ PendingAction UndoRequest Black)
+                        Nothing
                     )
-            case transition stateWithUndo (AcceptUndo White) of
+            case transition stateWithUndo (AcceptUndo White (Time 0)) of
               Right tr2 -> case tr2.newState of
-                State _ moves2 (Active turn2 _ _) -> do
+                State _ moves2 (Active turn2 _ _ _) -> do
                   length moves2 @?= 0
                   turn2 @?= Black
                 other -> fail $ "Expected Active, got " <> show other
@@ -184,7 +190,7 @@ test_onlineUndoCount =
         let blackMove = (head startBlackMoves).move
         case transition initialState (MakeMove Black blackMove (Time 0)) of
           Right tr1 -> case tr1.newState of
-            State _ _ (Active _ whiteMoves _) -> do
+            State _ _ (Active _ whiteMoves _ _) -> do
               let whiteMove = case whiteMoves of
                     (mc : _) -> mc.move
                     [] -> error "no white moves"
@@ -199,10 +205,11 @@ test_onlineUndoCount =
                               Black
                               (validMovesForPosition moves2)
                               (Just $ PendingAction UndoRequest Black)
+                              Nothing
                           )
-                  case transition stateWithUndo (AcceptUndo White) of
+                  case transition stateWithUndo (AcceptUndo White (Time 0)) of
                     Right tr3 -> case tr3.newState of
-                      State _ moves3 (Active turn3 _ _) -> do
+                      State _ moves3 (Active turn3 _ _ _) -> do
                         length moves3 @?= 0
                         turn3 @?= Black
                       other -> fail $ "Expected Active, got " <> show other

--- a/backend/test/Hnefatafl/Game/OnlineTest.hs
+++ b/backend/test/Hnefatafl/Game/OnlineTest.hs
@@ -18,6 +18,7 @@ import Hnefatafl.Game.Common (
  )
 import Hnefatafl.Game.Online (
   Event (..),
+  GameClock (..),
   Phase (..),
   State (..),
   TransitionResult (..),
@@ -43,17 +44,17 @@ fromStore store =
     store.storedMoves
     store.storedOutcome
     store.storedPendingAction
-    Nothing
+    Untimed
 
 mkActiveState :: PlayerColor -> [AppliedMove] -> Maybe PendingAction -> State
 mkActiveState turn moves pending =
   let board = currentBoard moves
       validMoves = validMovesForPosition moves
-   in State board moves (Active turn validMoves pending Nothing)
+   in State board moves (Active turn validMoves pending) Untimed
 
 genEvent :: State -> Maybe (Gen Event)
-genEvent (State _ _ (Finished _)) = Nothing
-genEvent (State _ moves (Active turn validMoves pending _)) =
+genEvent (State _ _ (Finished _) _) = Nothing
+genEvent (State _ moves (Active turn validMoves pending) _) =
   Just $
     frequency $
       concat
@@ -91,7 +92,7 @@ genEvent (State _ moves (Active turn validMoves pending _)) =
 
 initialState :: State
 initialState =
-  State startBoard [] (Active Black (toList startBlackMoves) Nothing Nothing)
+  State startBoard [] (Active Black (toList startBlackMoves) Nothing) Untimed
 
 genSequence :: State -> Gen [(Event, TransitionResult)]
 genSequence s = case genEvent s of
@@ -130,7 +131,7 @@ test_onlineCancellation =
             move = (head startBlackMoves).move
         case transition st (MakeMove Black move (Time 0)) of
           Right tr -> case tr.newState of
-            State _ _ (Active _ _ p _) -> p @?= Nothing
+            State _ _ (Active _ _ p) _ -> p @?= Nothing
             other -> fail $ "Expected Active, got " <> show other
           Left e -> fail $ "Expected Right, got Left " <> show e
     , testCase "Move preserves own draw offer" $ do
@@ -138,7 +139,7 @@ test_onlineCancellation =
             move = (head startBlackMoves).move
         case transition st (MakeMove Black move (Time 0)) of
           Right tr -> case tr.newState of
-            State _ _ (Active _ _ p _) -> p @?= Just (PendingAction DrawOffer Black)
+            State _ _ (Active _ _ p) _ -> p @?= Just (PendingAction DrawOffer Black)
             other -> fail $ "Expected Active, got " <> show other
           Left e -> fail $ "Expected Right, got Left " <> show e
     , testCase "Move cancels opponent's undo request" $ do
@@ -146,7 +147,7 @@ test_onlineCancellation =
             move = (head startBlackMoves).move
         case transition st (MakeMove Black move (Time 0)) of
           Right tr -> case tr.newState of
-            State _ _ (Active _ _ p _) -> p @?= Nothing
+            State _ _ (Active _ _ p) _ -> p @?= Nothing
             other -> fail $ "Expected Active, got " <> show other
           Left e -> fail $ "Expected Right, got Left " <> show e
     , testCase "Move preserves own undo request" $ do
@@ -154,7 +155,7 @@ test_onlineCancellation =
             move = (head startBlackMoves).move
         case transition st (MakeMove Black move (Time 0)) of
           Right tr -> case tr.newState of
-            State _ _ (Active _ _ p _) -> p @?= Just (PendingAction UndoRequest Black)
+            State _ _ (Active _ _ p) _ -> p @?= Just (PendingAction UndoRequest Black)
             other -> fail $ "Expected Active, got " <> show other
           Left e -> fail $ "Expected Right, got Left " <> show e
     ]
@@ -167,7 +168,7 @@ test_onlineUndoCount =
         let move = (head startBlackMoves).move
         case transition initialState (MakeMove Black move (Time 0)) of
           Right tr -> do
-            let State board1 moves1 _ = tr.newState
+            let State board1 moves1 _ _ = tr.newState
                 stateWithUndo =
                   State
                     board1
@@ -176,11 +177,11 @@ test_onlineUndoCount =
                         White
                         (validMovesForPosition moves1)
                         (Just $ PendingAction UndoRequest Black)
-                        Nothing
                     )
+                    Untimed
             case transition stateWithUndo (AcceptUndo White (Time 0)) of
               Right tr2 -> case tr2.newState of
-                State _ moves2 (Active turn2 _ _ _) -> do
+                State _ moves2 (Active turn2 _ _) _ -> do
                   length moves2 @?= 0
                   turn2 @?= Black
                 other -> fail $ "Expected Active, got " <> show other
@@ -190,13 +191,13 @@ test_onlineUndoCount =
         let blackMove = (head startBlackMoves).move
         case transition initialState (MakeMove Black blackMove (Time 0)) of
           Right tr1 -> case tr1.newState of
-            State _ _ (Active _ whiteMoves _ _) -> do
+            State _ _ (Active _ whiteMoves _) _ -> do
               let whiteMove = case whiteMoves of
                     (mc : _) -> mc.move
                     [] -> error "no white moves"
               case transition tr1.newState (MakeMove White whiteMove (Time 0)) of
                 Right tr2 -> do
-                  let State board2 moves2 _ = tr2.newState
+                  let State board2 moves2 _ _ = tr2.newState
                       stateWithUndo =
                         State
                           board2
@@ -205,11 +206,11 @@ test_onlineUndoCount =
                               Black
                               (validMovesForPosition moves2)
                               (Just $ PendingAction UndoRequest Black)
-                              Nothing
                           )
+                          Untimed
                   case transition stateWithUndo (AcceptUndo White (Time 0)) of
                     Right tr3 -> case tr3.newState of
-                      State _ moves3 (Active turn3 _ _ _) -> do
+                      State _ moves3 (Active turn3 _ _) _ -> do
                         length moves3 @?= 0
                         turn3 @?= Black
                       other -> fail $ "Expected Active, got " <> show other

--- a/backend/test/Hnefatafl/Game/TestUtil.hs
+++ b/backend/test/Hnefatafl/Game/TestUtil.hs
@@ -1,6 +1,21 @@
-module Hnefatafl.Game.TestUtil where
+module Hnefatafl.Game.TestUtil (
+  -- * Persistence store
+  PersistenceStore (..),
+  emptyStore,
+  applyEvent,
+  applyEvents,
 
-import Chronos (Time (..))
+  -- * Test data
+  dummyMove,
+  mkMoves,
+
+  -- * Clock test helpers
+  mkTC,
+  mkRemaining,
+  remainingSec,
+) where
+
+import Chronos (Time (..), Timespan (..), getTimespan)
 import Hnefatafl.Bindings (startBoard)
 import Hnefatafl.Core.Data (
   BlackWinCondition (..),
@@ -8,8 +23,14 @@ import Hnefatafl.Core.Data (
   Move (..),
   Outcome (..),
   PlayerColor (..),
+  RemainingTime,
+  Seconds (..),
+  TimeControl (..),
   WhiteWinCondition (..),
+  mkRemainingTime,
+  toTimespan,
  )
+import Refined.Unsafe (reallyUnsafeRefine)
 import Hnefatafl.Game.Common (
   AppliedMove (..),
   DomainEvent (..),
@@ -84,6 +105,25 @@ applyEvent evt store = case evt of
   UndoDeclined -> store{storedPendingAction = Nothing}
   OfferCancelled -> store{storedPendingAction = Nothing}
   OfferAutoCancelled _ _ -> store{storedPendingAction = Nothing}
+  ClockUpdated _ -> store
 
 applyEvents :: [DomainEvent] -> PersistenceStore -> PersistenceStore
 applyEvents evts store = foldl' (flip applyEvent) store evts
+
+-- * Clock test helpers
+
+mkTC :: Int -> Int -> TimeControl
+mkTC initial inc =
+  TimeControl
+    (reallyUnsafeRefine (Seconds initial))
+    (reallyUnsafeRefine (Seconds inc))
+
+mkRemaining :: Int -> RemainingTime
+mkRemaining sec =
+  case mkRemainingTime (Timespan (fromIntegral sec * 1_000_000_000)) of
+    Just r -> r
+    Nothing -> error "mkRemaining: negative"
+
+remainingSec :: RemainingTime -> Int
+remainingSec r =
+  fromIntegral (getTimespan (toTimespan r) `div` 1_000_000_000)

--- a/backend/test/Hnefatafl/Interpreter/Storage/SQLite/ClockStateTest.hs
+++ b/backend/test/Hnefatafl/Interpreter/Storage/SQLite/ClockStateTest.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Hnefatafl.Interpreter.Storage.SQLite.ClockStateTest where
+
+import Chronos (now)
+import Hnefatafl.Core.Data as CoreData
+import Hnefatafl.Effect.Storage
+import Hnefatafl.Game.TestUtil (mkRemaining)
+import Hnefatafl.Interpreter.Storage.SQLite.Util
+import Optics
+import Test.Hspec (Spec, around, describe, it)
+
+spec_ClockState :: Spec
+spec_ClockState =
+  around withSharedDB $ do
+    describe "clock state" $ do
+      it "returns Nothing for a game with no clock state" $ \conn -> do
+        currentTime <- now
+        let game =
+              baseGame currentTime
+                & #gameId
+                .~ GameId "no-clock-game"
+                & #mode
+                .~ Online Nothing Nothing
+        resultEquals
+          ( runTransaction $ do
+              insertGame game
+              getOnlineClockState game.gameId
+          )
+          Nothing
+          conn
+
+      it "round-trips a clock state" $ \conn -> do
+        currentTime <- now
+        let game =
+              baseGame currentTime
+                & #gameId
+                .~ GameId "clock-game"
+                & #mode
+                .~ Online Nothing Nothing
+            cs =
+              ClockState
+                (mkRemaining 300)
+                (mkRemaining 300)
+                currentTime
+        resultEquals
+          ( runTransaction $ do
+              insertGame game
+              setOnlineClockState game.gameId cs
+              getOnlineClockState game.gameId
+          )
+          (Just cs)
+          conn

--- a/backend/test/Hnefatafl/Interpreter/Storage/SQLite/TimeControlTest.hs
+++ b/backend/test/Hnefatafl/Interpreter/Storage/SQLite/TimeControlTest.hs
@@ -7,6 +7,7 @@ import Hnefatafl.Core.Data as CoreData
 import Hnefatafl.Effect.Storage
 import Hnefatafl.Interpreter.Storage.SQLite.Util
 import Optics
+import Refined.Unsafe (reallyUnsafeRefine)
 import Test.Hspec (Spec, around, describe, it)
 
 spec_TimeControl :: Spec
@@ -17,8 +18,10 @@ spec_TimeControl =
         currentTime <- now
         let game =
               baseGame currentTime
-                & #gameId .~ GameId "untimed-game"
-                & #mode .~ Online Nothing Nothing
+                & #gameId
+                .~ GameId "untimed-game"
+                & #mode
+                .~ Online Nothing Nothing
         resultEquals
           ( runTransaction $ do
               insertGame game
@@ -31,9 +34,14 @@ spec_TimeControl =
         currentTime <- now
         let game =
               baseGame currentTime
-                & #gameId .~ GameId "timed-game"
-                & #mode .~ Online Nothing Nothing
-            tc = TimeControl (Seconds 300) (Seconds 3)
+                & #gameId
+                .~ GameId "timed-game"
+                & #mode
+                .~ Online Nothing Nothing
+            tc =
+              TimeControl
+                (reallyUnsafeRefine (Seconds 300))
+                (reallyUnsafeRefine (Seconds 3))
         resultEquals
           ( runTransaction $ do
               insertGame game

--- a/backend/test/Hnefatafl/Interpreter/Storage/SQLite/TimeControlTest.hs
+++ b/backend/test/Hnefatafl/Interpreter/Storage/SQLite/TimeControlTest.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Hnefatafl.Interpreter.Storage.SQLite.TimeControlTest where
+
+import Chronos (now)
+import Hnefatafl.Core.Data as CoreData
+import Hnefatafl.Effect.Storage
+import Hnefatafl.Interpreter.Storage.SQLite.Util
+import Optics
+import Test.Hspec (Spec, around, describe, it)
+
+spec_TimeControl :: Spec
+spec_TimeControl =
+  around withSharedDB $ do
+    describe "time control" $ do
+      it "returns Nothing for a game with no time control" $ \conn -> do
+        currentTime <- now
+        let game =
+              baseGame currentTime
+                & #gameId .~ GameId "untimed-game"
+                & #mode .~ Online Nothing Nothing
+        resultEquals
+          ( runTransaction $ do
+              insertGame game
+              getOnlineTimeControl game.gameId
+          )
+          Nothing
+          conn
+
+      it "round-trips a time control" $ \conn -> do
+        currentTime <- now
+        let game =
+              baseGame currentTime
+                & #gameId .~ GameId "timed-game"
+                & #mode .~ Online Nothing Nothing
+            tc = TimeControl (Seconds 300) (Seconds 3)
+        resultEquals
+          ( runTransaction $ do
+              insertGame game
+              setOnlineTimeControl game.gameId tc
+              getOnlineTimeControl game.gameId
+          )
+          (Just tc)
+          conn

--- a/backend/test/Hnefatafl/Interpreter/Storage/SQLite/Util.hs
+++ b/backend/test/Hnefatafl/Interpreter/Storage/SQLite/Util.hs
@@ -13,15 +13,15 @@ import Effectful
 import Effectful.Concurrent (Concurrent, runConcurrent)
 import Effectful.Katip (KatipE, runKatipE)
 import Hnefatafl.Core.Data as CoreData
-import Hnefatafl.Effect.Storage
 import Hnefatafl.Effect.Clock (Clock)
-import Hnefatafl.Interpreter.Clock.IO (runClockIO)
-import Hnefatafl.Metrics (HMetrics)
+import Hnefatafl.Effect.Storage
 import Hnefatafl.Effect.Trace (Trace)
+import Hnefatafl.Interpreter.Clock.IO (runClockIO)
 import Hnefatafl.Interpreter.Metrics.NoOp (runMetricsNoOp)
 import Hnefatafl.Interpreter.Storage.SQLite (runStorageSQLite)
 import Hnefatafl.Interpreter.Trace.NoOp (runTraceNoOp)
 import Hnefatafl.Logging (withNoLogEnv)
+import Hnefatafl.Metrics (HMetrics)
 import Paths_hnefatafl (getDataFileName)
 import Test.Hspec.Expectations.Pretty
 
@@ -34,7 +34,10 @@ withSharedDB action = do
   SQLite3.exec (connectionHandle conn) schemaSQL
   connectionVar <- MVar.newMVar conn
   result <- action connectionVar
-  close conn
+  -- Take the connection from the MVar before closing, so we don't
+  -- close it while a worker thread has it checked out via modifyMVar.
+  conn' <- MVar.takeMVar connectionVar
+  close conn'
   return result
 
 -- | Run storage effects with automatic rollback for test isolation.
@@ -44,7 +47,13 @@ withSharedDB action = do
 -- helper don't exercise that path, so the value is an 'error' that
 -- fails loudly if expectations change.
 runStorageSQLiteWithRollback ::
-  (IOE :> es, KatipE :> es, Concurrent :> es, Trace :> es, HMetrics :> es, Clock :> es) =>
+  ( IOE :> es
+  , KatipE :> es
+  , Concurrent :> es
+  , Trace :> es
+  , HMetrics :> es
+  , Clock :> es
+  ) =>
   MVar Connection -> Eff (Storage : es) a -> Eff es a
 runStorageSQLiteWithRollback connectionVar action = do
   -- Start transaction
@@ -55,12 +64,12 @@ runStorageSQLiteWithRollback connectionVar action = do
   -- Always rollback to ensure test isolation
   liftIO $ execute_ conn "ROLLBACK"
   return result
-  where
-    unusedOpenConn =
-      error
-        "runStorageSQLiteWithRollback: connection-replacement openConn \
-        \invoked unexpectedly (ConnectionUnrecoverableException raised \
-        \inside a test wrapped in BEGIN/ROLLBACK)"
+ where
+  unusedOpenConn =
+    error
+      "runStorageSQLiteWithRollback: connection-replacement openConn \
+      \invoked unexpectedly (ConnectionUnrecoverableException raised \
+      \inside a test wrapped in BEGIN/ROLLBACK)"
 
 -- | Run storage effects in a transaction and roll back.
 -- Catches synchronous exceptions and returns them as Left.

--- a/backend/test/Hnefatafl/SearchTest.hs
+++ b/backend/test/Hnefatafl/SearchTest.hs
@@ -47,17 +47,27 @@ spec_timeout_behavior =
         let board = startBoard
         let isBlackTurn = True
         let zobristHashes = [] :: [Word64]
-        let timeoutMs = 50 -- Increase timeout to see if search naturally takes longer
+        let timeoutMs = 50
         let timeout = SearchTimeout timeoutMs
-        let marginMs = 50 -- Allow larger margin
         start <- getTime Monotonic
         _ <- searchWithTimeout board isBlackTurn zobristHashes timeout False
         end <- getTime Monotonic
 
         let elapsedMs = fromIntegral (toNanoSecs (diffTimeSpec end start)) / 1000000 :: Double
+        -- Lower bound: the search must run at least the timeout, proving
+        -- it does not stop before the stop flag is set.
         let expectedMin = fromIntegral timeoutMs :: Double
-        let expectedMax = fromIntegral (timeoutMs + marginMs) :: Double
-
+        -- Upper bound: the search must stop soon after the flag, proving
+        -- the stop mechanism fires. It cannot be tight: wall-clock
+        -- elapsed also includes transposition-table setup/teardown and
+        -- finishing the deepening iteration in flight when the flag is
+        -- set (polled between nodes, not preemptively), which alone is
+        -- ~90ms and spikes higher under the parallel test runner's
+        -- scheduler jitter. A *broken* stop mechanism instead runs the
+        -- full depth-8 search, which from the start position takes over
+        -- two minutes — so a generous ceiling still catches it
+        -- unambiguously while absorbing the scheduling tail.
+        let expectedMax = 2000 :: Double
         elapsedMs `shouldSatisfy` (\t -> t >= expectedMin && t <= expectedMax)
 
 spec_exception_handling :: Spec

--- a/backend/test/Hnefatafl/SelfPlayTest.hs
+++ b/backend/test/Hnefatafl/SelfPlayTest.hs
@@ -604,7 +604,6 @@ runAllGamesToCompletion processingState = do
   -- Then process any remaining unprocessed games using the standard gameActor
   gameActor processingState eventChan
 
-  liftIO $ putStrLn "getting chan contents"
   -- Collect all events from the channel
   events <- drainTChan eventChan
 
@@ -659,49 +658,21 @@ spec_round_trip_snapshot_preservation =
                   runLabeled @"new" (runSearchTest (TestSearchConfig testGameNotation)) $
                     runLabeled @"old" (runSearchTest (TestSearchConfig testGameNotation)) $ do
                       -- Path 1: Direct processing
-                      liftIO $ putStrLn "=== Direct Processing Path ==="
                       directState <- atomically createState
-                      directSnapshot <- atomically $ takeSnapshot directState
-                      liftIO $
-                        putStrLn $
-                          "Direct initial state: "
-                            <> show (length directSnapshot.unprocessedGames)
-                            <> " unprocessed, "
-                            <> show (length directSnapshot.completedGames)
-                            <> " completed"
                       (directFinalState, directEvents) <-
                         runAllGamesToCompletion directState
-                      liftIO $
-                        putStrLn $
-                          "Direct path completed " <> show (length directEvents) <> " events"
 
-                      -- Path 2: Snapshot round trip
-                      liftIO $ putStrLn "=== Snapshot Round Trip Path ==="
-                      snapshotState <- atomically createState -- Create identical initial state
+                      snapshotState <- atomically createState
                       initialSnapshot <- atomically $ takeSnapshot snapshotState
 
                       -- Serialize to JSON
                       saveProcessingStateSnapshot snapshotFile initialSnapshot
-                      liftIO $ putStrLn "Snapshot saved to file"
-
-                      -- Deserialize from JSON
                       restoredSnapshot <- loadOrCreateStateSnapshot snapshotFile "dummy_file.txt"
-                      liftIO $ putStrLn "Snapshot loaded from file"
-                      liftIO $
-                        putStrLn $
-                          "Restored snapshot: "
-                            <> show (length restoredSnapshot.unprocessedGames)
-                            <> " unprocessed, "
-                            <> show (length restoredSnapshot.completedGames)
-                            <> " completed"
 
                       -- Process restored state
                       restoredState <- atomically $ mkProcessingState restoredSnapshot
                       (restoredFinalState, restoredEvents) <-
                         runAllGamesToCompletion restoredState
-                      liftIO $
-                        putStrLn $
-                          "Restored path completed " <> show (length restoredEvents) <> " events"
 
                       pure (directFinalState, directEvents, restoredFinalState, restoredEvents)
 
@@ -711,44 +682,8 @@ spec_round_trip_snapshot_preservation =
           case result of
             Left err -> error $ "Round trip test failed: " <> err
             Right (directFinalState, directEvents, restoredFinalState, restoredEvents) -> do
-              liftIO $ putStrLn $ "Direct events count: " <> show (length directEvents)
-              liftIO $ putStrLn $ "Restored events count: " <> show (length restoredEvents)
-              liftIO $
-                putStrLn $
-                  "Final states equal: "
-                    <> show (compareFinalStates directFinalState restoredFinalState)
-              liftIO $
-                putStrLn $
-                  "Event sequences equal: "
-                    <> show (compareEventSequences directEvents restoredEvents)
-
-              -- Find the exact difference
-              let sortedDirect = sort directEvents
-                  sortedRestored = sort restoredEvents
-                  extraInRestored = sortedRestored \\ sortedDirect
-                  missingInRestored = sortedDirect \\ sortedRestored
-              liftIO $
-                putStrLn $
-                  "Extra events in restored: " <> show (length extraInRestored)
-              liftIO $
-                putStrLn $
-                  "Missing events in restored: " <> show (length missingInRestored)
-              unless (null extraInRestored) $
-                liftIO $
-                  putStrLn $
-                    "First extra: " <> show (viaNonEmpty head extraInRestored)
-              unless (null missingInRestored) $
-                liftIO $
-                  putStrLn $
-                    "First missing: " <> show (viaNonEmpty head missingInRestored)
-
-              -- Verify final states are equivalent
               compareFinalStates directFinalState restoredFinalState `shouldBe` True
-
-              -- Verify event sequences are equivalent
               compareEventSequences directEvents restoredEvents `shouldBe` True
-
-              liftIO $ putStrLn "Round trip test completed successfully!"
 
 -- | Generate a test positions file from the known TestTest game at various move counts
 generateTestPositionsFile ::
@@ -780,8 +715,6 @@ spec_single_game_actor :: Spec
 spec_single_game_actor =
   describe "Single game actor test" $ do
     it "should run a single actor and complete one game" $ do
-      liftIO $ putStrLn "=== Testing single game actor ==="
-
       -- Setup
       tempDir <- createTempDirectory "/tmp" "single-actor-test"
       let testPositionsFile = tempDir </> "single_position.txt"
@@ -805,23 +738,13 @@ spec_single_game_actor =
                   processingState <- atomically $ mkProcessingState snapshot
                   eventChan <- atomically newTChan
 
-                  liftIO $ putStrLn "About to run single game actor..."
-
                   gameActor processingState eventChan
-                  liftIO $ putStrLn "Actor run, collecting events..."
                   drainTChan eventChan
 
       removeDirectoryRecursive tempDir
 
       case result of
         Left err -> error $ "Single actor test failed: " <> err
-        Right events -> do
-          liftIO $
-            putStrLn $
-              "Single actor test completed with " <> show (length events) <> " events"
-          length events `shouldSatisfy` (>= 2) -- Should have at least GameClaimed and GameCompleted
-      case result of
-        Left err -> error $ "Test failed: " <> err
         Right events -> do
           -- Verify we got the expected number of events
           let claimedEvents = filter isGameClaimed events
@@ -885,21 +808,10 @@ spec_end_to_end_parallel_self_play :: Spec
 spec_end_to_end_parallel_self_play =
   describe "End-to-end parallel self-play" $ do
     it "should run 4 actors processing 10 test games to completion" $ do
-      liftIO $ putStrLn "=== Starting end-to-end test ==="
-
-      -- Setup: Create temp directory and test files
       tempDir <- createTempDirectory "/tmp" "self-play-test"
-      liftIO $ putStrLn $ "Created temp directory: " <> tempDir
-
       let testPositionsFile = tempDir </> "test_positions.txt"
       runGenerateTestPositionsFile testPositionsFile
-      liftIO $ putStrLn "Generated test positions file"
-
-      -- Run the parallel self-play
       let config = TestSearchConfig{gameNotation = testGameNotation}
-
-      liftIO $ putStrLn "About to start parallel self-play..."
-
       _ <- runEff $
         runErrorNoCallStack @Text $
           runFileSystem $
@@ -907,31 +819,15 @@ spec_end_to_end_parallel_self_play =
               runLabeled @"new" (runSearchTest config) $
                 runLabeled @"old" (runSearchTest config) $ do
                   eventChan <- atomically newTChan
-
-                  -- Start self-play in the background
                   selfPlayAsync <-
                     async $
                       runSelfPlayParallel
-                        4 -- 4 actors
+                        4
                         (VersionId "test-new")
                         (VersionId "test-old")
                         tempDir
                         testPositionsFile
                         eventChan
-
-                  -- Add initial logging
-                  liftIO $ putStrLn "Starting self-play, will wait for completion..."
-
-                  -- Wait for self-play to complete
                   wait selfPlayAsync
-
-                  -- Collect all events now that processing is done
-                  events <- drainTChan eventChan
-
-                  liftIO $
-                    putStrLn $
-                      "Self-play complete. Total events: " <> show (length events)
-                  pure events
-
-      -- Cleanup
+                  drainTChan eventChan
       removeDirectoryRecursive tempDir

--- a/ci-build-and-test.sh
+++ b/ci-build-and-test.sh
@@ -36,3 +36,6 @@ build_target "frontend.check"
 
 print_header "Checking generated frontend types"
 build_target "frontend.check-generated-types"
+
+print_header "Running frontend e2e tests"
+nix run .#test-e2e

--- a/flake.lock
+++ b/flake.lock
@@ -16,22 +16,6 @@
         "type": "github"
       }
     },
-    "HTTP_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1451647621,
-        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
-        "owner": "phadej",
-        "repo": "HTTP",
-        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
-        "type": "github"
-      },
-      "original": {
-        "owner": "phadej",
-        "repo": "HTTP",
-        "type": "github"
-      }
-    },
     "backend": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -54,48 +38,7 @@
       },
       "parent": []
     },
-    "backend_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_3",
-        "git-hooks": "git-hooks_2",
-        "haskellNix": "haskellNix_2",
-        "nixpkgs": [
-          "frontend",
-          "backend",
-          "haskellNix",
-          "nixpkgs-unstable"
-        ]
-      },
-      "locked": {
-        "path": "../backend",
-        "type": "path"
-      },
-      "original": {
-        "path": "../backend",
-        "type": "path"
-      },
-      "parent": [
-        "frontend"
-      ]
-    },
     "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-32_2": {
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
@@ -129,23 +72,6 @@
         "type": "github"
       }
     },
-    "cabal-34_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645834128,
-        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.4",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
     "cabal-36": {
       "flake": false,
       "locked": {
@@ -163,40 +89,7 @@
         "type": "github"
       }
     },
-    "cabal-36_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1669081697,
-        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.6",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
     "cardano-shell": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1608537748,
-        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "type": "github"
-      }
-    },
-    "cardano-shell_2": {
       "flake": false,
       "locked": {
         "lastModified": 1608537748,
@@ -246,39 +139,6 @@
       }
     },
     "flake-compat_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1672831974,
-        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
-        "owner": "input-output-hk",
-        "repo": "flake-compat",
-        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "hkm/gitlab-fix",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_5": {
       "flake": false,
       "locked": {
         "lastModified": 1747046372,
@@ -348,29 +208,13 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
-      "inputs": {
-        "systems": "systems_4"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "frontend": {
       "inputs": {
-        "backend": "backend_2",
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_3"
+        "backend": [
+          "backend"
+        ],
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "path": "./frontend",
@@ -406,27 +250,7 @@
       "inputs": {
         "flake-compat": "flake-compat_3",
         "gitignore": "gitignore_2",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1760663237,
-        "narHash": "sha256-BflA6U4AM1bzuRMR8QqzPXqh8sWVCNDzOdsxXEguJIc=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "git-hooks_3": {
-      "inputs": {
-        "flake-compat": "flake-compat_5",
-        "gitignore": "gitignore_3",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1759523803,
@@ -465,29 +289,6 @@
       }
     },
     "gitignore_2": {
-      "inputs": {
-        "nixpkgs": [
-          "frontend",
-          "backend",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_3": {
       "inputs": {
         "nixpkgs": [
           "git-hooks",
@@ -541,23 +342,6 @@
         "type": "github"
       }
     },
-    "hackage-for-stackage_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1762993591,
-        "narHash": "sha256-j5s47Qi1TPppivEn7ndVEj0Qtsx+MY+KIoaexe1jhqo=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "53be51c664a12aefa8d5ce36a5b18fdfbfee0bea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "for-stackage",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
     "hackage-internal": {
       "flake": false,
       "locked": {
@@ -566,38 +350,6 @@
         "owner": "input-output-hk",
         "repo": "hackage.nix",
         "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
-    "hackage-internal_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1750307553,
-        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
-    "hackage_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1762993602,
-        "narHash": "sha256-2EbxPw/rZJJrPKCkLuH84wKur3hE/M+skpAIO8050e0=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "12828c64d34a2472ee8a3424ecde537fac2f3b32",
         "type": "github"
       },
       "original": {
@@ -665,61 +417,6 @@
         "type": "github"
       }
     },
-    "haskellNix_2": {
-      "inputs": {
-        "HTTP": "HTTP_2",
-        "cabal-32": "cabal-32_2",
-        "cabal-34": "cabal-34_2",
-        "cabal-36": "cabal-36_2",
-        "cardano-shell": "cardano-shell_2",
-        "flake-compat": "flake-compat_4",
-        "hackage": "hackage_2",
-        "hackage-for-stackage": "hackage-for-stackage_2",
-        "hackage-internal": "hackage-internal_2",
-        "hls": "hls_2",
-        "hls-1.10": "hls-1.10_2",
-        "hls-2.0": "hls-2.0_2",
-        "hls-2.10": "hls-2.10_2",
-        "hls-2.11": "hls-2.11_2",
-        "hls-2.2": "hls-2.2_2",
-        "hls-2.3": "hls-2.3_2",
-        "hls-2.4": "hls-2.4_2",
-        "hls-2.5": "hls-2.5_2",
-        "hls-2.6": "hls-2.6_2",
-        "hls-2.7": "hls-2.7_2",
-        "hls-2.8": "hls-2.8_2",
-        "hls-2.9": "hls-2.9_2",
-        "hpc-coveralls": "hpc-coveralls_2",
-        "iserv-proxy": "iserv-proxy_2",
-        "nixpkgs": [
-          "frontend",
-          "backend",
-          "haskellNix",
-          "nixpkgs-unstable"
-        ],
-        "nixpkgs-2305": "nixpkgs-2305_2",
-        "nixpkgs-2311": "nixpkgs-2311_2",
-        "nixpkgs-2405": "nixpkgs-2405_2",
-        "nixpkgs-2411": "nixpkgs-2411_2",
-        "nixpkgs-2505": "nixpkgs-2505_2",
-        "nixpkgs-unstable": "nixpkgs-unstable_2",
-        "old-ghc-nix": "old-ghc-nix_2",
-        "stackage": "stackage_2"
-      },
-      "locked": {
-        "lastModified": 1762995137,
-        "narHash": "sha256-+TYOG+x2s6KjCiSt7ahCNatGY42bA5luiKZQYIXYsM8=",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "3c9e83afafb0f40b67b89ed98b356a4922a65760",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "type": "github"
-      }
-    },
     "hls": {
       "flake": false,
       "locked": {
@@ -753,41 +450,7 @@
         "type": "github"
       }
     },
-    "hls-1.10_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1680000865,
-        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "1.10.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "hls-2.0": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1687698105,
-        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "783905f211ac63edf982dd1889c671653327e441",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.0.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.0_2": {
       "flake": false,
       "locked": {
         "lastModified": 1687698105,
@@ -821,41 +484,7 @@
         "type": "github"
       }
     },
-    "hls-2.10_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1743069404,
-        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.10.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "hls-2.11": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1747306193,
-        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.11.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.11_2": {
       "flake": false,
       "locked": {
         "lastModified": 1747306193,
@@ -889,41 +518,7 @@
         "type": "github"
       }
     },
-    "hls-2.2_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1693064058,
-        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.2.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "hls-2.3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1695910642,
-        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.3.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.3_2": {
       "flake": false,
       "locked": {
         "lastModified": 1695910642,
@@ -957,41 +552,7 @@
         "type": "github"
       }
     },
-    "hls-2.4_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1699862708,
-        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.4.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "hls-2.5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1701080174,
-        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.5.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.5_2": {
       "flake": false,
       "locked": {
         "lastModified": 1701080174,
@@ -1025,41 +586,7 @@
         "type": "github"
       }
     },
-    "hls-2.6_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1705325287,
-        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.6.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "hls-2.7": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1708965829,
-        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.7.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.7_2": {
       "flake": false,
       "locked": {
         "lastModified": 1708965829,
@@ -1093,23 +620,6 @@
         "type": "github"
       }
     },
-    "hls-2.8_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1715153580,
-        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.8.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "hls-2.9": {
       "flake": false,
       "locked": {
@@ -1123,39 +633,6 @@
       "original": {
         "owner": "haskell",
         "ref": "2.9.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.9_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1719993701,
-        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.9.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1741604408,
-        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "682d6894c94087da5e566771f25311c47e145359",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -1176,40 +653,7 @@
         "type": "github"
       }
     },
-    "hpc-coveralls_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1607498076,
-        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "type": "github"
-      }
-    },
     "iserv-proxy": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1755243078,
-        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
-        "owner": "stable-haskell",
-        "repo": "iserv-proxy",
-        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "stable-haskell",
-        "ref": "iserv-syms",
-        "repo": "iserv-proxy",
-        "type": "github"
-      }
-    },
-    "iserv-proxy_2": {
       "flake": false,
       "locked": {
         "lastModified": 1755243078,
@@ -1258,39 +702,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-2305_2": {
-      "locked": {
-        "lastModified": 1705033721,
-        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2311": {
-      "locked": {
-        "lastModified": 1719957072,
-        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2311_2": {
       "locked": {
         "lastModified": 1719957072,
         "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
@@ -1322,22 +734,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-2405_2": {
-      "locked": {
-        "lastModified": 1735564410,
-        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-24.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2411": {
       "locked": {
         "lastModified": 1751290243,
@@ -1354,22 +750,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-2411_2": {
-      "locked": {
-        "lastModified": 1748037224,
-        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-24.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2505": {
       "locked": {
         "lastModified": 1764560356,
@@ -1377,22 +757,6 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-25.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2505_2": {
-      "locked": {
-        "lastModified": 1757716134,
-        "narHash": "sha256-OYoZLWvmCnCTCJQwaQlpK1IO5nkLnLLoUW8wwmPmrfU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e85b5aa112a98805a016bbf6291e726debbc448a",
         "type": "github"
       },
       "original": {
@@ -1436,22 +800,6 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1759070547,
-        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable_3": {
-      "locked": {
         "lastModified": 1762943920,
         "narHash": "sha256-ITeH8GBpQTw9457ICZBddQEBjlXMmilML067q0e6vqY=",
         "owner": "NixOS",
@@ -1468,22 +816,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1759070547,
-        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1775639890,
         "narHash": "sha256-9O9gNidrdzcb7vgKGtff7QiLtr0IsVaCi0pAXm8anhQ=",
         "owner": "NixOS",
@@ -1498,7 +830,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1759070547,
         "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
@@ -1531,35 +863,18 @@
         "type": "github"
       }
     },
-    "old-ghc-nix_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1631092763,
-        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
-        "owner": "angerman",
-        "repo": "old-ghc-nix",
-        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "angerman",
-        "ref": "master",
-        "repo": "old-ghc-nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "backend": "backend",
         "flake-utils": "flake-utils_2",
         "frontend": "frontend",
-        "git-hooks": "git-hooks_3",
+        "git-hooks": "git-hooks_2",
         "nixpkgs": [
           "backend",
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-unstable": "nixpkgs-unstable_3"
+        "nixpkgs-unstable": "nixpkgs-unstable_2"
       }
     },
     "stackage": {
@@ -1570,22 +885,6 @@
         "owner": "input-output-hk",
         "repo": "stackage.nix",
         "rev": "90ee92c0a2563844f078873e9b977bc1619ae9a1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "type": "github"
-      }
-    },
-    "stackage_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1762992791,
-        "narHash": "sha256-Uf7wEOIktTXL2wu5M8e6jEdVKurriASZZH30DX8lbj0=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "0468b36ba2ff14e0efe1d1c45e8a2a4d31680a8b",
         "type": "github"
       },
       "original": {
@@ -1625,21 +924,6 @@
       }
     },
     "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
     git-hooks.url = "github:cachix/git-hooks.nix";
     backend.url = "./backend";
     frontend.url = "./frontend";
+    frontend.inputs.backend.follows = "backend";
   };
 
   outputs = {
@@ -53,7 +54,7 @@
             type = "app";
             program = backend.apps.${system}."hnefatafl:test:hnefatafl-test".program;
           };
-          inherit (frontend.apps.${system}) generate-types;
+          inherit (frontend.apps.${system}) generate-types test-e2e;
           backend = backend.apps.${system};
         };
         devShells = {
@@ -73,6 +74,7 @@
               ];
               buildInputs = [
                 pythonEnv
+                pkgs.gh
               ];
               inherit shellHook;
             };

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.vite/

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .vite/
+test-results/

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,6 +1,6 @@
 # Hnefatafl Frontend — SolidJS TypeScript UI
 
-SolidJS single-page app with Vite. Currently runs entirely on mock backends (no real API integration yet).
+SolidJS single-page app with Vite. Talks to the Haskell backend over REST + WebSocket (see `src/api/`). Set `VITE_USE_MOCKS=true` to swap in the in-browser mock backends (`src/mocks/`) instead; without it the real services are used and Vite proxies `/ai`, `/online`, `/hotseat`, `/health`, `/version` to `http://localhost:8080`.
 
 ## Commands
 
@@ -89,7 +89,7 @@ interface GameState {
   boardRep: BoardRep;          // { black: Set<number>, white: Set<number>, king: number }
   moveHistory: Move[];         // { from, to, captures? }[]
   currentPlayer: PlayerColor;  // "black" | "white"
-  moves: MovesMap;             // Record<number, number[][]> — legal moves per square
+  moves: MovesMap;             // Record<number, { to: number; captures: number[] }[]> — legal moves per square
   capturedPieces: { black: number; white: number };
   gameOver: GameOverState | null;
   playerColor: PlayerColor | null;
@@ -124,7 +124,7 @@ Each game mode has a controller component that:
 Same 0-120 index space as the C engine (11x11 grid). `board-logic.ts` contains:
 - `BoardRep` — `{ black: Set<number>, white: Set<number>, king: number }`
 - `Move` — `{ from: number, to: number, captures?: number[] }`
-- `MovesMap` — `Record<number, number[][]>` (legal destinations grouped by square)
+- `MovesMap` — `Record<number, { to: number; captures: number[] }[]>` (legal destinations grouped by square)
 - `indexToAlgebraic()` — converts index to chess-style notation (a1-k11)
 - `startBoard` — initial piece placement (24 black, 12 white, 1 king)
 

--- a/frontend/e2e/game.test.ts
+++ b/frontend/e2e/game.test.ts
@@ -205,7 +205,7 @@ test.describe("Online timeout", () => {
 
   test("timeout displays correct game outcome", async ({ page }) => {
     await startOnlineGame(page);
-    await page.evaluate(() => (window as any).__simulateTimeout(100));
+    await page.evaluate(() => window.__simulateTimeout?.(100));
     await expect(desktop(page).locator(".game-status")).toContainText(
       "timeout",
       { timeout: 2000 },

--- a/frontend/e2e/game.test.ts
+++ b/frontend/e2e/game.test.ts
@@ -31,9 +31,7 @@ async function startHotseatGame(page: Page) {
 
 async function makeMove(page: Page, from: number, to: number) {
   await page.locator(`[data-index="${from}"]`).click();
-  await expect(
-    page.locator(`[data-index="${to}"].valid-move`),
-  ).toBeVisible();
+  await expect(page.locator(`[data-index="${to}"].valid-move`)).toBeVisible();
   await page.locator(`[data-index="${to}"]`).click();
 }
 
@@ -190,5 +188,27 @@ test.describe("History navigation", () => {
 
     await nextBtn.click();
     await expect(pieceAt(page, 3)).toBeVisible();
+  });
+});
+
+test.describe("Online timeout", () => {
+  async function startOnlineGame(page: Page) {
+    await page.goto("/");
+    await page.locator(".entries button").nth(2).click();
+    // Select a time control (first timed option)
+    await page.getByText("5 min", { exact: true }).click();
+    await page.getByRole("button", { name: "Create game" }).click();
+    await page.getByRole("button", { name: "Continue to game" }).click();
+    await expect(page.locator(".board")).toBeVisible();
+    await expect(livePieces(page)).toHaveCount(37);
+  }
+
+  test("timeout displays correct game outcome", async ({ page }) => {
+    await startOnlineGame(page);
+    await page.evaluate(() => (window as any).__simulateTimeout(100));
+    await expect(desktop(page).locator(".game-status")).toContainText(
+      "timeout",
+      { timeout: 2000 },
+    );
   });
 });

--- a/frontend/e2e/game.test.ts
+++ b/frontend/e2e/game.test.ts
@@ -212,3 +212,32 @@ test.describe("Online timeout", () => {
     );
   });
 });
+
+test.describe("Online clock", () => {
+  test("the side to move counts down in a timed game", async ({ page }) => {
+    await page.goto("/");
+    await page.locator(".entries button").nth(2).click();
+    // Play as Defenders (White); the mock's Black opponent makes the
+    // free opening move, after which White's clock runs continuously
+    // (the opponent will not move again until we do).
+    await page.getByText("Defenders", { exact: true }).click();
+    await page.getByText("5 min", { exact: true }).click();
+    await page.getByRole("button", { name: "Create game" }).click();
+    await page.getByRole("button", { name: "Continue to game" }).click();
+    await expect(page.locator(".board")).toBeVisible();
+    // White's clock begins at 5:00 and ticks down once Black has opened.
+    await expect(
+      desktop(page).locator(".player.white .player-clock"),
+    ).not.toHaveText("5:00", { timeout: 5000 });
+  });
+
+  test("an untimed game shows no clock", async ({ page }) => {
+    await page.goto("/");
+    await page.locator(".entries button").nth(2).click();
+    // Leave the default "Untimed" time control.
+    await page.getByRole("button", { name: "Create game" }).click();
+    await page.getByRole("button", { name: "Continue to game" }).click();
+    await expect(page.locator(".board")).toBeVisible();
+    await expect(desktop(page).locator(".player-clock")).toHaveCount(0);
+  });
+});

--- a/frontend/flake.lock
+++ b/frontend/flake.lock
@@ -108,15 +108,15 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -181,11 +181,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1760663237,
-        "narHash": "sha256-BflA6U4AM1bzuRMR8QqzPXqh8sWVCNDzOdsxXEguJIc=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -219,11 +219,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1777059376,
-        "narHash": "sha256-9yaV3UjJZ/YICt+3tWdcrXFaBHvLKrT0Nxv6Z9VFF4A=",
+        "lastModified": 1776888169,
+        "narHash": "sha256-BVNJOHk1RRT/Mc3bNCHdKN0KfjoKcuKUWHkHBSwy7DU=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6bf902fbd3dd24c1fbe27cf71058bddaec0a23c3",
+        "rev": "e811e4619a83fc98990a8a5700013ed0826d70e3",
         "type": "github"
       },
       "original": {
@@ -579,11 +579,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759070547,
-        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "lastModified": 1770073757,
+        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
         "type": "github"
       },
       "original": {

--- a/frontend/flake.nix
+++ b/frontend/flake.nix
@@ -41,6 +41,35 @@
             '';
           }}/bin/generate-types";
         };
+        apps.test-e2e = let
+          e2eSrc = pkgs.lib.sources.sourceByRegex ./. [
+            "src" "src/.*"
+            "e2e" "e2e/.*"
+            "vite.config.ts"
+            "playwright.config.ts"
+            "tsconfig.json"
+            "package.json"
+            "index.html"
+          ];
+        in {
+          type = "app";
+          program = "${pkgs.writeShellApplication {
+            name = "test-e2e";
+            runtimeInputs = [nodejs];
+            text = ''
+              workdir=$(mktemp -d)
+              trap 'rm -rf "$workdir"' EXIT
+              cp -r ${e2eSrc}/. "$workdir"
+              chmod -R u+w "$workdir"
+              cp -r --reflink=auto ${nodeModules}/node_modules "$workdir/node_modules"
+              chmod -R u+w "$workdir/node_modules"
+              cd "$workdir"
+              export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
+              export VITE_USE_MOCKS=true
+              npx playwright test
+            '';
+          }}/bin/test-e2e";
+        };
         packages = {
           # Mirrors `npm run check` from package.json (lint + typecheck + tests),
           # but uses pkgs.biome directly because importNpmLock doesn't

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -22,5 +22,6 @@ export default defineConfig({
     command: "npm run dev",
     port: 3000,
     reuseExistingServer: !process.env.CI,
+    env: { VITE_USE_MOCKS: "true" },
   },
 });

--- a/frontend/src/api/generated/rest.ts
+++ b/frontend/src/api/generated/rest.ts
@@ -643,6 +643,7 @@ export interface components {
         };
         ClockMs: {
             blackMs: number;
+            turnStartedAtMs: number;
             whiteMs: number;
         };
         CreateAiGameResponse: {
@@ -775,6 +776,7 @@ export interface components {
             type: "undoCancelled";
         } | {
             blackMs: number;
+            turnStartedAtMs: number;
             /** @enum {string} */
             type: "clockUpdated";
             whiteMs: number;

--- a/frontend/src/api/generated/rest.ts
+++ b/frontend/src/api/generated/rest.ts
@@ -404,7 +404,11 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json;charset=utf-8": components["schemas"]["CreateOnlineGameRequest"];
+                };
+            };
             responses: {
                 200: {
                     headers: {
@@ -413,6 +417,13 @@ export interface paths {
                     content: {
                         "application/json;charset=utf-8": components["schemas"]["CreateOnlineGameResponse"];
                     };
+                };
+                /** @description Invalid `body` */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
                 };
             };
         };
@@ -637,6 +648,9 @@ export interface components {
         CreateGameRequest: {
             playerColor: components["schemas"]["PlayerColor"];
         };
+        CreateOnlineGameRequest: {
+            timeControl?: components["schemas"]["TimeControl"];
+        };
         CreateOnlineGameResponse: {
             blackToken: string;
             gameId: components["schemas"]["GameId"];
@@ -780,6 +794,10 @@ export interface components {
             updatedBoard: components["schemas"]["ExternBoard"];
             /** Format: int64 */
             updatedZobristHash: number;
+        };
+        TimeControl: {
+            increment: number;
+            initialTime: number;
         };
         /** @description Valid moves keyed by origin position */
         ValidMovesMap: {

--- a/frontend/src/api/generated/rest.ts
+++ b/frontend/src/api/generated/rest.ts
@@ -641,6 +641,10 @@ export interface components {
             /** @enum {string} */
             type: "auth";
         };
+        ClockMs: {
+            blackMs: number;
+            whiteMs: number;
+        };
         CreateAiGameResponse: {
             gameId: components["schemas"]["GameId"];
             token: string;
@@ -715,6 +719,7 @@ export interface components {
         };
         OnlineServerMessage: {
             board: components["schemas"]["ApiBoard"];
+            clock?: components["schemas"]["ClockMs"];
             gameId: components["schemas"]["GameId"];
             history: components["schemas"]["HistoryEntry"][];
             pendingAction?: components["schemas"]["PendingActionPayload"];
@@ -726,6 +731,7 @@ export interface components {
             validMoves: components["schemas"]["ValidMovesMap"];
         } | {
             board: components["schemas"]["ApiBoard"];
+            clock?: components["schemas"]["ClockMs"];
             move: components["schemas"]["ApiMove"];
             side: components["schemas"]["PlayerColor"];
             status: components["schemas"]["ApiGameStatus"];
@@ -734,6 +740,7 @@ export interface components {
             type: "moveMade";
             validMoves: components["schemas"]["ValidMovesMap"];
         } | {
+            clock?: components["schemas"]["ClockMs"];
             status: components["schemas"]["ApiGameStatus"];
             /** @enum {string} */
             type: "gameOver";
@@ -753,6 +760,7 @@ export interface components {
             type: "undoRequested";
         } | {
             board: components["schemas"]["ApiBoard"];
+            clock?: components["schemas"]["ClockMs"];
             moveCount: number;
             status: components["schemas"]["ApiGameStatus"];
             turn: components["schemas"]["PlayerColor"];
@@ -765,6 +773,11 @@ export interface components {
         } | {
             /** @enum {string} */
             type: "undoCancelled";
+        } | {
+            blackMs: number;
+            /** @enum {string} */
+            type: "clockUpdated";
+            whiteMs: number;
         } | {
             /** @enum {string} */
             type: "opponentJoined";

--- a/frontend/src/api/online-game-service.ts
+++ b/frontend/src/api/online-game-service.ts
@@ -32,6 +32,7 @@ export interface OnlineGameService {
   acceptUndo(): void;
   declineUndo(): void;
   sendChat(message: string): void;
+  simulateTimeout?(delayMs?: number): void;
   events: Accessor<OnlineGameEvent | undefined>;
   connected: Accessor<boolean>;
   connecting: Accessor<boolean>;

--- a/frontend/src/api/online-game-service.ts
+++ b/frontend/src/api/online-game-service.ts
@@ -1,6 +1,7 @@
 import type { Accessor } from "solid-js";
 import { createSignal } from "solid-js";
 import type { Move, PlayerColor } from "../board-logic";
+import type { TimeControlValue } from "../gameOptions";
 import { api } from "./client";
 import type { components } from "./generated/rest";
 import {
@@ -18,6 +19,7 @@ type OnlineServerMessage = components["schemas"]["OnlineServerMessage"];
 export interface OnlineGameService {
   createGame(opts: {
     creatorColor: PlayerColor;
+    timeControl: TimeControlValue | null;
   }): Promise<{ playerToken: string; inviteToken: string }>;
   connect(token: string): void;
   disconnect(): void;
@@ -110,7 +112,9 @@ export function createOnlineGameService(opts?: {
 
   return {
     async createGame(opts) {
-      const { data, error } = await api.POST("/online");
+      const { data, error } = await api.POST("/online", {
+        body: { timeControl: opts.timeControl ?? undefined },
+      });
       if (error || !data) throw new Error("Failed to create online game");
       const playerToken =
         opts.creatorColor === "white" ? data.whiteToken : data.blackToken;

--- a/frontend/src/api/online-game-service.ts
+++ b/frontend/src/api/online-game-service.ts
@@ -50,6 +50,7 @@ function mapServerMessage(
         moves: mapMoves(msg.validMoves),
         moveHistory: mapHistory(msg.history),
         gameOver: mapGameOver(msg.status),
+        clock: msg.clock ?? null,
       };
     case "moveMade":
       return {
@@ -58,6 +59,7 @@ function mapServerMessage(
         boardRep: mapBoard(msg.board),
         currentPlayer: msg.turn,
         moves: mapMoves(msg.validMoves),
+        clock: msg.clock ?? null,
       };
     case "gameOver":
       if (msg.status.state === "finished") {
@@ -65,12 +67,14 @@ function mapServerMessage(
           type: "gameOver",
           winner: msg.status.winner,
           reason: msg.status.reason,
+          clock: msg.clock ?? null,
         };
       }
       return {
         type: "gameOver",
         winner: "draw",
         reason: "unknown",
+        clock: msg.clock ?? null,
       };
     case "drawOffered":
       return { type: "drawOffer", by: msg.by };
@@ -81,7 +85,11 @@ function mapServerMessage(
     case "undoRequested":
       return { type: "undoRequest", by: msg.by };
     case "undoAccepted":
-      return { type: "undoAccepted", moveCount: msg.moveCount };
+      return {
+        type: "undoAccepted",
+        moveCount: msg.moveCount,
+        clock: msg.clock ?? null,
+      };
     case "undoDeclined":
       return { type: "undoDeclined" };
     case "undoCancelled":
@@ -91,7 +99,10 @@ function mapServerMessage(
     case "opponentLeft":
       return { type: "opponentLeft" };
     case "clockUpdated":
-      return undefined;
+      return {
+        type: "clockUpdated",
+        clock: { whiteMs: msg.whiteMs, blackMs: msg.blackMs },
+      };
   }
 }
 

--- a/frontend/src/api/online-game-service.ts
+++ b/frontend/src/api/online-game-service.ts
@@ -37,7 +37,9 @@ export interface OnlineGameService {
   connecting: Accessor<boolean>;
 }
 
-function mapServerMessage(msg: OnlineServerMessage): OnlineGameEvent {
+function mapServerMessage(
+  msg: OnlineServerMessage,
+): OnlineGameEvent | undefined {
   switch (msg.type) {
     case "gameState":
       return {
@@ -88,6 +90,8 @@ function mapServerMessage(msg: OnlineServerMessage): OnlineGameEvent {
       return { type: "opponentJoined" };
     case "opponentLeft":
       return { type: "opponentLeft" };
+    case "clockUpdated":
+      return undefined;
   }
 }
 

--- a/frontend/src/api/online-game-service.ts
+++ b/frontend/src/api/online-game-service.ts
@@ -105,7 +105,11 @@ function mapServerMessage(
     case "clockUpdated":
       return {
         type: "clockUpdated",
-        clock: { whiteMs: msg.whiteMs, blackMs: msg.blackMs },
+        clock: {
+          whiteMs: msg.whiteMs,
+          blackMs: msg.blackMs,
+          turnStartedAtMs: msg.turnStartedAtMs,
+        },
       };
   }
 }

--- a/frontend/src/api/online-game-service.ts
+++ b/frontend/src/api/online-game-service.ts
@@ -89,6 +89,9 @@ function mapServerMessage(
       return {
         type: "undoAccepted",
         moveCount: msg.moveCount,
+        boardRep: mapBoard(msg.board),
+        currentPlayer: msg.turn,
+        moves: mapMoves(msg.validMoves),
         clock: msg.clock ?? null,
       };
     case "undoDeclined":

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -85,6 +85,9 @@ export type OnlineGameEvent =
   | {
       type: "undoAccepted";
       moveCount: number;
+      boardRep: BoardRep;
+      currentPlayer: PlayerColor;
+      moves: MovesMap;
       clock: ClockMs | null;
     }
   | { type: "undoDeclined" }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -49,6 +49,9 @@ export type AiGameEvent =
 export interface ClockMs {
   whiteMs: number;
   blackMs: number;
+  // Unix ms at which the current turn began. The active player's
+  // displayed time is whiteMs/blackMs minus the time elapsed since.
+  turnStartedAtMs: number;
 }
 
 export type OnlineGameEvent =

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -46,6 +46,11 @@ export type AiGameEvent =
       gameOver: GameOverState | null;
     };
 
+export interface ClockMs {
+  whiteMs: number;
+  blackMs: number;
+}
+
 export type OnlineGameEvent =
   | {
       type: "initialState";
@@ -55,6 +60,7 @@ export type OnlineGameEvent =
       moves: MovesMap;
       moveHistory: Move[];
       gameOver: GameOverState | null;
+      clock: ClockMs | null;
     }
   | {
       type: "moveMade";
@@ -62,15 +68,26 @@ export type OnlineGameEvent =
       boardRep: BoardRep;
       currentPlayer: PlayerColor;
       moves: MovesMap;
+      clock: ClockMs | null;
     }
-  | { type: "gameOver"; winner: PlayerColor | "draw"; reason: string }
+  | {
+      type: "gameOver";
+      winner: PlayerColor | "draw";
+      reason: string;
+      clock: ClockMs | null;
+    }
   | { type: "opponentJoined" }
   | { type: "opponentLeft" }
   | { type: "drawOffer"; by: PlayerColor }
   | { type: "drawDeclined" }
   | { type: "drawCancelled" }
   | { type: "undoRequest"; by: PlayerColor }
-  | { type: "undoAccepted"; moveCount: number }
+  | {
+      type: "undoAccepted";
+      moveCount: number;
+      clock: ClockMs | null;
+    }
   | { type: "undoDeclined" }
   | { type: "undoCancelled" }
+  | { type: "clockUpdated"; clock: ClockMs }
   | { type: "chat"; message: string };

--- a/frontend/src/components/GameLayout.test.ts
+++ b/frontend/src/components/GameLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatClockMs } from "./GameLayout";
+import { formatClockMs, hasUndoableMove } from "./GameLayout";
 
 describe("formatClockMs", () => {
   it("formats minutes and seconds", () => {
@@ -24,5 +24,23 @@ describe("formatClockMs", () => {
 
   it("clamps negative to zero", () => {
     expect(formatClockMs(-1000)).toBe("0:00");
+  });
+});
+
+describe("hasUndoableMove", () => {
+  it("online Black can undo after its own first move", () => {
+    expect(hasUndoableMove("black", 0)).toBe(false);
+    expect(hasUndoableMove("black", 1)).toBe(true);
+  });
+
+  it("online White cannot undo until it has moved", () => {
+    // After Black's opening move (length 1) White has not moved yet.
+    expect(hasUndoableMove("white", 1)).toBe(false);
+    expect(hasUndoableMove("white", 2)).toBe(true);
+  });
+
+  it("hotseat/AI (no player color) can undo any played move", () => {
+    expect(hasUndoableMove(null, 0)).toBe(false);
+    expect(hasUndoableMove(null, 1)).toBe(true);
   });
 });

--- a/frontend/src/components/GameLayout.test.ts
+++ b/frontend/src/components/GameLayout.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { formatClockMs } from "./GameLayout";
+
+describe("formatClockMs", () => {
+  it("formats minutes and seconds", () => {
+    expect(formatClockMs(300_000)).toBe("5:00");
+  });
+
+  it("pads seconds to two digits", () => {
+    expect(formatClockMs(65_000)).toBe("1:05");
+  });
+
+  it("formats zero", () => {
+    expect(formatClockMs(0)).toBe("0:00");
+  });
+
+  it("truncates sub-second values", () => {
+    expect(formatClockMs(5_999)).toBe("0:05");
+  });
+
+  it("formats large values", () => {
+    expect(formatClockMs(3_600_000)).toBe("60:00");
+  });
+
+  it("clamps negative to zero", () => {
+    expect(formatClockMs(-1000)).toBe("0:00");
+  });
+});

--- a/frontend/src/components/GameLayout.test.ts
+++ b/frontend/src/components/GameLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatClockMs, hasUndoableMove } from "./GameLayout";
+import { displayedClockMs, formatClockMs, hasUndoableMove } from "./GameLayout";
 
 describe("formatClockMs", () => {
   it("formats minutes and seconds", () => {
@@ -42,5 +42,35 @@ describe("hasUndoableMove", () => {
   it("hotseat/AI (no player color) can undo any played move", () => {
     expect(hasUndoableMove(null, 0)).toBe(false);
     expect(hasUndoableMove(null, 1)).toBe(true);
+  });
+});
+
+describe("displayedClockMs", () => {
+  const clock = { whiteMs: 300_000, blackMs: 250_000, turnStartedAtMs: 10_000 };
+
+  it("shows the stored bank for the side not to move", () => {
+    // White is running; Black's clock is idle at its bank.
+    expect(displayedClockMs(clock, "black", "white", true, 40_000)).toBe(
+      250_000,
+    );
+  });
+
+  it("counts the side to move down from the turn start", () => {
+    // White to move, 3s elapsed since turnStartedAt (10s → 13s).
+    expect(displayedClockMs(clock, "white", "white", true, 13_000)).toBe(
+      297_000,
+    );
+  });
+
+  it("does not tick before the clock is running", () => {
+    expect(displayedClockMs(clock, "white", "white", false, 999_999)).toBe(
+      300_000,
+    );
+  });
+
+  it("clamps a flagged clock to zero", () => {
+    expect(
+      displayedClockMs(clock, "white", "white", true, 10_000 + 999_999),
+    ).toBe(0);
   });
 });

--- a/frontend/src/components/GameLayout.tsx
+++ b/frontend/src/components/GameLayout.tsx
@@ -21,6 +21,13 @@ import SkipForwardIcon from "./ui/icons/SkipForwardIcon";
 import UndoIcon from "./ui/icons/UndoIcon";
 import Toolbar from "./ui/Toolbar";
 
+export function formatClockMs(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
 interface ActionDef {
   label: string;
   icon: JSX.Element;
@@ -141,6 +148,11 @@ export default function GameLayout(props: GameLayoutProps) {
     game.store.game.playerColor === "black" ? "white" : "black";
   const bottomColor = (): Side => opposite(topColor());
   const playerName = (c: Side) => (c === "black" ? blackName() : whiteName());
+  const clockForSide = (c: Side) => {
+    const clock = game.store.game.clock;
+    if (!clock) return null;
+    return c === "white" ? clock.whiteMs : clock.blackMs;
+  };
 
   return (
     <div class="main-layout">
@@ -163,7 +175,11 @@ export default function GameLayout(props: GameLayoutProps) {
         >
           <span class="player-name">{playerName(topColor())}</span>
           <span class="player-rule" />
-          <span class="player-clock">7:28</span>
+          <Show when={clockForSide(topColor()) != null}>
+            <span class="player-clock">
+              {formatClockMs(clockForSide(topColor())!)}
+            </span>
+          </Show>
         </div>
         <div class={`captures top ${bottomColor()}`}>
           <For
@@ -185,7 +201,11 @@ export default function GameLayout(props: GameLayoutProps) {
         >
           <span class="player-name">{playerName(bottomColor())}</span>
           <span class="player-rule" />
-          <span class="player-clock">7:28</span>
+          <Show when={clockForSide(bottomColor()) != null}>
+            <span class="player-clock">
+              {formatClockMs(clockForSide(bottomColor())!)}
+            </span>
+          </Show>
         </div>
         <div class="game-actions">
           <For each={activeActions()}>
@@ -221,9 +241,11 @@ export default function GameLayout(props: GameLayoutProps) {
             <span class={`mobile-player-name ${playerState("black")}`}>
               {blackName()}
             </span>
-            <span class={`mobile-player-clock ${playerState("black")}`}>
-              7:28
-            </span>
+            <Show when={clockForSide("black") != null}>
+              <span class={`mobile-player-clock ${playerState("black")}`}>
+                {formatClockMs(clockForSide("black")!)}
+              </span>
+            </Show>
           </div>
         </div>
         <span class="mobile-vs">vs</span>
@@ -232,9 +254,11 @@ export default function GameLayout(props: GameLayoutProps) {
             <span class={`mobile-player-name ${playerState("white")}`}>
               {whiteName()}
             </span>
-            <span class={`mobile-player-clock ${playerState("white")}`}>
-              7:28
-            </span>
+            <Show when={clockForSide("white") != null}>
+              <span class={`mobile-player-clock ${playerState("white")}`}>
+                {formatClockMs(clockForSide("white")!)}
+              </span>
+            </Show>
           </div>
           <div class="captures black">
             <For

--- a/frontend/src/components/GameLayout.tsx
+++ b/frontend/src/components/GameLayout.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "@solidjs/router";
 import { createSignal, For, type JSX, Match, Show, Switch } from "solid-js";
-import type { Move } from "../board-logic";
+import type { Move, PlayerColor } from "../board-logic";
 import { type GameMode, useGame } from "../game-context";
 import AiInfoPanel from "./AiInfoPanel";
 import Board from "./Board";
@@ -26,6 +26,19 @@ export function formatClockMs(ms: number): string {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+// Whether the Undo button has a move this player is allowed to take
+// back. Online play only lets a player undo their own move, and the
+// server rejects a request otherwise: Black moves first so needs at
+// least one move played, White needs two. Hotseat / AI has no player
+// color, so any played move is undoable.
+export function hasUndoableMove(
+  playerColor: PlayerColor | null,
+  historyLength: number,
+): boolean {
+  if (playerColor === "white") return historyLength >= 2;
+  return historyLength >= 1;
 }
 
 interface ActionDef {
@@ -110,10 +123,13 @@ export default function GameLayout(props: GameLayoutProps) {
       label: "Undo",
       icon: <UndoIcon />,
       onClick: () => props.onUndo?.(),
-      disabled: () =>
-        !gameActive() ||
-        game.store.game.moveHistory.length === 0 ||
-        anyOfferPending(),
+      disabled: () => {
+        if (!gameActive() || anyOfferPending()) return true;
+        return !hasUndoableMove(
+          game.store.game.playerColor,
+          game.store.game.moveHistory.length,
+        );
+      },
     },
     resign: {
       label: "Resign",

--- a/frontend/src/components/GameLayout.tsx
+++ b/frontend/src/components/GameLayout.tsx
@@ -1,5 +1,14 @@
 import { useNavigate } from "@solidjs/router";
-import { createSignal, For, type JSX, Match, Show, Switch } from "solid-js";
+import {
+  createSignal,
+  For,
+  type JSX,
+  Match,
+  onCleanup,
+  Show,
+  Switch,
+} from "solid-js";
+import type { ClockMs } from "../api/types";
 import type { Move, PlayerColor } from "../board-logic";
 import { type GameMode, useGame } from "../game-context";
 import AiInfoPanel from "./AiInfoPanel";
@@ -39,6 +48,22 @@ export function hasUndoableMove(
 ): boolean {
   if (playerColor === "white") return historyLength >= 2;
   return historyLength >= 1;
+}
+
+// The time to show for one side. Once the clock is running, the side
+// to move counts down from the turn start (so it stays accurate across
+// reconnects and network delay); every other side shows its stored
+// bank. Clamped at zero.
+export function displayedClockMs(
+  clock: ClockMs,
+  side: PlayerColor,
+  currentPlayer: PlayerColor,
+  running: boolean,
+  nowMs: number,
+): number {
+  const bank = side === "white" ? clock.whiteMs : clock.blackMs;
+  if (!running || currentPlayer !== side) return bank;
+  return Math.max(0, bank - (nowMs - clock.turnStartedAtMs));
 }
 
 interface ActionDef {
@@ -87,6 +112,13 @@ export default function GameLayout(props: GameLayoutProps) {
 
   const [movesSheetOpen, setMovesSheetOpen] = createSignal(false);
   const [chatSheetOpen, setChatSheetOpen] = createSignal(false);
+
+  // Drives the live clock countdown. The stored clock holds
+  // server-authoritative values; the running side's display is
+  // recomputed against the current time on each tick.
+  const [nowMs, setNowMs] = createSignal(Date.now());
+  const clockTimer = setInterval(() => setNowMs(Date.now()), 250);
+  onCleanup(() => clearInterval(clockTimer));
 
   const playerState = (color: "black" | "white"): PlayerState => {
     if (game.store.game.gameOver) return "ended";
@@ -164,10 +196,20 @@ export default function GameLayout(props: GameLayoutProps) {
     game.store.game.playerColor === "black" ? "white" : "black";
   const bottomColor = (): Side => opposite(topColor());
   const playerName = (c: Side) => (c === "black" ? blackName() : whiteName());
-  const clockForSide = (c: Side) => {
+  const clockForSide = (c: Side): number | null => {
     const clock = game.store.game.clock;
     if (!clock) return null;
-    return c === "white" ? clock.whiteMs : clock.blackMs;
+    // The clock only runs once the first move is played, matching the
+    // server, so an unmoved game shows the initial banks statically.
+    const running =
+      !game.store.game.gameOver && game.store.game.moveHistory.length > 0;
+    return displayedClockMs(
+      clock,
+      c,
+      game.store.game.currentPlayer,
+      running,
+      nowMs(),
+    );
   };
 
   return (

--- a/frontend/src/components/OnlineSetupModal.tsx
+++ b/frontend/src/components/OnlineSetupModal.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from "@solidjs/router";
 import { createSignal, Match, type Setter, Switch } from "solid-js";
 import { useOnlineGame } from "../api/contexts";
 import type { PlayerColor } from "../board-logic";
-import { sideOptions, timeOptions } from "../gameOptions";
+import { getTimeControl, sideOptions, timeOptions } from "../gameOptions";
 import { useToasts } from "../toast-context";
 import Modal from "./ui/Modal";
 import OptionPicker from "./ui/OptionPicker";
@@ -53,7 +53,10 @@ export default function OnlineSetupModal(props: OnlineSetupModalProps) {
           : "white"
         : (side() as PlayerColor);
     try {
-      const tokens = await online.createGame({ creatorColor: chosenSide });
+      const tokens = await online.createGame({
+        creatorColor: chosenSide,
+        timeControl: getTimeControl(timeControl()),
+      });
       setPlayerToken(tokens.playerToken);
       setInviteToken(tokens.inviteToken);
       setStep("share");

--- a/frontend/src/controllers/OnlineController.tsx
+++ b/frontend/src/controllers/OnlineController.tsx
@@ -54,28 +54,6 @@ function OnlineController() {
     online.disconnect();
   });
 
-  // Client-side clock tick: decrements the active player's displayed
-  // time by wall-clock elapsed since the last tick. Server-authoritative
-  // values snap the clock on each moveMade/clockUpdated event; this
-  // interval fills the visual gap between server updates.
-  const tickHandle = setInterval(() => {
-    const clock = game.store.game.clock;
-    if (!clock || game.store.game.gameOver) return;
-    const active = game.store.game.currentPlayer;
-    if (active === "white") {
-      game.setClock({
-        whiteMs: Math.max(0, clock.whiteMs - 1000),
-        blackMs: clock.blackMs,
-      });
-    } else {
-      game.setClock({
-        whiteMs: clock.whiteMs,
-        blackMs: Math.max(0, clock.blackMs - 1000),
-      });
-    }
-  }, 1000);
-  onCleanup(() => clearInterval(tickHandle));
-
   createEffect(
     on(online.events, (event) => {
       if (!event) return;

--- a/frontend/src/controllers/OnlineController.tsx
+++ b/frontend/src/controllers/OnlineController.tsx
@@ -107,10 +107,7 @@ function OnlineController() {
           clearAll();
           break;
         case "undoAccepted":
-          for (let i = 0; i < event.moveCount; i++) {
-            game.undoLastMove();
-          }
-          game.setClock(event.clock);
+          game.applyExternalUndo(event);
           setOutgoingUndo(false);
           setIncoming(undefined);
           break;

--- a/frontend/src/controllers/OnlineController.tsx
+++ b/frontend/src/controllers/OnlineController.tsx
@@ -54,6 +54,28 @@ function OnlineController() {
     online.disconnect();
   });
 
+  // Client-side clock tick: decrements the active player's displayed
+  // time by wall-clock elapsed since the last tick. Server-authoritative
+  // values snap the clock on each moveMade/clockUpdated event; this
+  // interval fills the visual gap between server updates.
+  const tickHandle = setInterval(() => {
+    const clock = game.store.game.clock;
+    if (!clock || game.store.game.gameOver) return;
+    const active = game.store.game.currentPlayer;
+    if (active === "white") {
+      game.setClock({
+        whiteMs: Math.max(0, clock.whiteMs - 1000),
+        blackMs: clock.blackMs,
+      });
+    } else {
+      game.setClock({
+        whiteMs: clock.whiteMs,
+        blackMs: Math.max(0, clock.blackMs - 1000),
+      });
+    }
+  }, 1000);
+  onCleanup(() => clearInterval(tickHandle));
+
   createEffect(
     on(online.events, (event) => {
       if (!event) return;

--- a/frontend/src/controllers/OnlineController.tsx
+++ b/frontend/src/controllers/OnlineController.tsx
@@ -67,6 +67,7 @@ function OnlineController() {
             moveHistory: event.moveHistory,
             playerColor: event.playerColor,
             gameOver: event.gameOver,
+            clock: event.clock,
             players:
               event.playerColor === "black"
                 ? { black: "You", white: "Opponent" }
@@ -80,14 +81,19 @@ function OnlineController() {
           break;
         case "gameOver":
           game.setGameOver({ winner: event.winner, reason: event.reason });
+          game.setClock(event.clock);
           clearAll();
           break;
         case "undoAccepted":
           for (let i = 0; i < event.moveCount; i++) {
             game.undoLastMove();
           }
+          game.setClock(event.clock);
           setOutgoingUndo(false);
           setIncoming(undefined);
+          break;
+        case "clockUpdated":
+          game.setClock(event.clock);
           break;
         case "drawOffer":
           setNotice(undefined); // discard any stale notice

--- a/frontend/src/game-context.test.tsx
+++ b/frontend/src/game-context.test.tsx
@@ -106,6 +106,88 @@ describe("game context — state transitions", () => {
   });
 });
 
+function startBoardRep() {
+  return {
+    black: new Set(startBoard.black),
+    white: new Set(startBoard.white),
+    king: startBoard.king,
+  };
+}
+
+describe("game context — external undo", () => {
+  it("trims history by moveCount and applies the authoritative position", () => {
+    const ctx = setupContext();
+    ctx.applyMove(blackMove);
+    ctx.applyMove(whiteMove);
+    expect(ctx.store.game.moveHistory).toHaveLength(2);
+    ctx.applyExternalUndo({
+      moveCount: 2,
+      boardRep: startBoardRep(),
+      currentPlayer: "black",
+      moves: { 3: [{ to: 2, captures: [] }] },
+      clock: null,
+    });
+    expect(ctx.store.game.moveHistory).toHaveLength(0);
+    expect(ctx.store.game.currentPlayer).toBe("black");
+    expect(ctx.store.game.boardRep.black).toEqual(startBoard.black);
+    expect(ctx.store.game.boardRep.white).toEqual(startBoard.white);
+    expect(ctx.store.game.boardRep.king).toBe(startBoard.king);
+  });
+
+  it("repopulates the legal moves map from the server", () => {
+    // undoLastMove alone leaves moves empty; the server's authoritative
+    // move list must be applied so the player can move again.
+    const ctx = setupContext();
+    ctx.applyMove(blackMove);
+    ctx.applyExternalUndo({
+      moveCount: 1,
+      boardRep: startBoardRep(),
+      currentPlayer: "black",
+      moves: {
+        3: [{ to: 2, captures: [] }],
+        5: [{ to: 4, captures: [] }],
+      },
+      clock: null,
+    });
+    expect(ctx.store.game.moves).toEqual({
+      3: [{ to: 2, captures: [] }],
+      5: [{ to: 4, captures: [] }],
+    });
+  });
+
+  it("updates the clock when the event carries one", () => {
+    const ctx = setupContext();
+    ctx.applyMove(blackMove);
+    ctx.applyExternalUndo({
+      moveCount: 1,
+      boardRep: startBoardRep(),
+      currentPlayer: "black",
+      moves: {},
+      clock: { whiteMs: 300_000, blackMs: 280_000 },
+    });
+    expect(ctx.store.game.clock).toEqual({
+      whiteMs: 300_000,
+      blackMs: 280_000,
+    });
+  });
+
+  it("resets historyCursor to the present", async () => {
+    const ctx = setupContext();
+    ctx.applyMove(blackMove);
+    ctx.applyMove(whiteMove);
+    await ctx.viewPrev();
+    expect(ctx.store.game.historyCursor).toBe(1);
+    ctx.applyExternalUndo({
+      moveCount: 1,
+      boardRep: startBoardRep(),
+      currentPlayer: "white",
+      moves: {},
+      clock: null,
+    });
+    expect(ctx.store.game.historyCursor).toBe(0);
+  });
+});
+
 function snapshotBoard(ctx: ReturnType<typeof useGame>) {
   return {
     black: new Set(ctx.store.game.boardRep.black),

--- a/frontend/src/game-context.test.tsx
+++ b/frontend/src/game-context.test.tsx
@@ -277,3 +277,82 @@ describe("game context — derived signals", () => {
     expect(ctx.lastMove()?.to).toBe(blackMove.to);
   });
 });
+
+describe("game context — clock state", () => {
+  it("clock defaults to null", () => {
+    const ctx = setupContext();
+    expect(ctx.store.game.clock).toBeNull();
+  });
+
+  it("initGame with clock sets clock on store", () => {
+    const ctx = setupContext();
+    ctx.initGame({
+      boardRep: {
+        black: new Set(startBoard.black),
+        white: new Set(startBoard.white),
+        king: startBoard.king,
+      },
+      clock: { whiteMs: 300_000, blackMs: 250_000 },
+    });
+    expect(ctx.store.game.clock).toEqual({
+      whiteMs: 300_000,
+      blackMs: 250_000,
+    });
+  });
+
+  it("applyExternalMove with clock updates clock", () => {
+    const ctx = setupContext();
+    ctx.initGame({
+      boardRep: {
+        black: new Set(startBoard.black),
+        white: new Set(startBoard.white),
+        king: startBoard.king,
+      },
+      clock: { whiteMs: 300_000, blackMs: 300_000 },
+    });
+    const board = ctx.store.game.boardRep;
+    ctx.applyExternalMove({
+      move: blackMove,
+      boardRep: board,
+      currentPlayer: "white",
+      moves: {},
+      clock: { whiteMs: 300_000, blackMs: 295_000 },
+    });
+    expect(ctx.store.game.clock).toEqual({
+      whiteMs: 300_000,
+      blackMs: 295_000,
+    });
+  });
+
+  it("applyExternalMove without clock leaves clock unchanged", () => {
+    const ctx = setupContext();
+    ctx.initGame({
+      boardRep: {
+        black: new Set(startBoard.black),
+        white: new Set(startBoard.white),
+        king: startBoard.king,
+      },
+      clock: { whiteMs: 300_000, blackMs: 300_000 },
+    });
+    const board = ctx.store.game.boardRep;
+    ctx.applyExternalMove({
+      move: blackMove,
+      boardRep: board,
+      currentPlayer: "white",
+      moves: {},
+    });
+    expect(ctx.store.game.clock).toEqual({
+      whiteMs: 300_000,
+      blackMs: 300_000,
+    });
+  });
+
+  it("setClock updates clock on store", () => {
+    const ctx = setupContext();
+    ctx.setClock({ whiteMs: 100_000, blackMs: 200_000 });
+    expect(ctx.store.game.clock).toEqual({
+      whiteMs: 100_000,
+      blackMs: 200_000,
+    });
+  });
+});

--- a/frontend/src/game-context.test.tsx
+++ b/frontend/src/game-context.test.tsx
@@ -163,11 +163,12 @@ describe("game context — external undo", () => {
       boardRep: startBoardRep(),
       currentPlayer: "black",
       moves: {},
-      clock: { whiteMs: 300_000, blackMs: 280_000 },
+      clock: { whiteMs: 300_000, blackMs: 280_000, turnStartedAtMs: 0 },
     });
     expect(ctx.store.game.clock).toEqual({
       whiteMs: 300_000,
       blackMs: 280_000,
+      turnStartedAtMs: 0,
     });
   });
 
@@ -374,11 +375,12 @@ describe("game context — clock state", () => {
         white: new Set(startBoard.white),
         king: startBoard.king,
       },
-      clock: { whiteMs: 300_000, blackMs: 250_000 },
+      clock: { whiteMs: 300_000, blackMs: 250_000, turnStartedAtMs: 0 },
     });
     expect(ctx.store.game.clock).toEqual({
       whiteMs: 300_000,
       blackMs: 250_000,
+      turnStartedAtMs: 0,
     });
   });
 
@@ -390,7 +392,7 @@ describe("game context — clock state", () => {
         white: new Set(startBoard.white),
         king: startBoard.king,
       },
-      clock: { whiteMs: 300_000, blackMs: 300_000 },
+      clock: { whiteMs: 300_000, blackMs: 300_000, turnStartedAtMs: 0 },
     });
     const board = ctx.store.game.boardRep;
     ctx.applyExternalMove({
@@ -398,11 +400,12 @@ describe("game context — clock state", () => {
       boardRep: board,
       currentPlayer: "white",
       moves: {},
-      clock: { whiteMs: 300_000, blackMs: 295_000 },
+      clock: { whiteMs: 300_000, blackMs: 295_000, turnStartedAtMs: 0 },
     });
     expect(ctx.store.game.clock).toEqual({
       whiteMs: 300_000,
       blackMs: 295_000,
+      turnStartedAtMs: 0,
     });
   });
 
@@ -414,7 +417,7 @@ describe("game context — clock state", () => {
         white: new Set(startBoard.white),
         king: startBoard.king,
       },
-      clock: { whiteMs: 300_000, blackMs: 300_000 },
+      clock: { whiteMs: 300_000, blackMs: 300_000, turnStartedAtMs: 0 },
     });
     const board = ctx.store.game.boardRep;
     ctx.applyExternalMove({
@@ -426,15 +429,17 @@ describe("game context — clock state", () => {
     expect(ctx.store.game.clock).toEqual({
       whiteMs: 300_000,
       blackMs: 300_000,
+      turnStartedAtMs: 0,
     });
   });
 
   it("setClock updates clock on store", () => {
     const ctx = setupContext();
-    ctx.setClock({ whiteMs: 100_000, blackMs: 200_000 });
+    ctx.setClock({ whiteMs: 100_000, blackMs: 200_000, turnStartedAtMs: 0 });
     expect(ctx.store.game.clock).toEqual({
       whiteMs: 100_000,
       blackMs: 200_000,
+      turnStartedAtMs: 0,
     });
   });
 });

--- a/frontend/src/game-context.tsx
+++ b/frontend/src/game-context.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
 } from "solid-js";
 import { createStore } from "solid-js/store";
+import type { ClockMs } from "./api/types";
 import {
   applyMoveToBoardRep,
   type BoardRep,
@@ -33,6 +34,7 @@ export interface GameState {
   players: { black: string; white: string };
   historyCursor: number;
   loading: boolean;
+  clock: ClockMs | null;
 }
 
 interface GameContextValue {
@@ -56,8 +58,10 @@ interface GameContextValue {
     boardRep: BoardRep;
     currentPlayer: PlayerColor;
     moves: MovesMap;
+    clock?: ClockMs | null;
   }) => void;
   setMoves: (moves: MovesMap) => void;
+  setClock: (clock: ClockMs | null) => void;
   setGameOver: (state: GameOverState | null) => void;
   reconcile: (response: {
     moves: MovesMap;
@@ -91,6 +95,7 @@ function initialGameState(): GameState {
     players: { black: "Black", white: "White" },
     historyCursor: 0,
     loading: true,
+    clock: null,
   };
 }
 
@@ -172,18 +177,25 @@ export const GameProvider: ParentComponent = (props) => {
     boardRep: BoardRep;
     currentPlayer: PlayerColor;
     moves: MovesMap;
+    clock?: ClockMs | null;
   }): void {
-    setStore("game", {
+    const update: Partial<GameState> = {
       moveHistory: [...store.game.moveHistory, event.move],
       historyCursor: 0,
       currentPlayer: event.currentPlayer,
       boardRep: event.boardRep,
       moves: event.moves,
-    });
+    };
+    if ("clock" in event) update.clock = event.clock;
+    setStore("game", update);
   }
 
   function setMovesAction(moves: MovesMap): void {
     setStore("game", "moves", moves);
+  }
+
+  function setClockAction(clock: ClockMs | null): void {
+    setStore("game", "clock", clock);
   }
 
   function setGameOverAction(state: GameOverState | null): void {
@@ -292,6 +304,7 @@ export const GameProvider: ParentComponent = (props) => {
     applyMove,
     applyExternalMove,
     setMoves: setMovesAction,
+    setClock: setClockAction,
     setGameOver: setGameOverAction,
     reconcile: reconcileAction,
     undoLastMove,

--- a/frontend/src/game-context.tsx
+++ b/frontend/src/game-context.tsx
@@ -60,6 +60,13 @@ interface GameContextValue {
     moves: MovesMap;
     clock?: ClockMs | null;
   }) => void;
+  applyExternalUndo: (event: {
+    moveCount: number;
+    boardRep: BoardRep;
+    currentPlayer: PlayerColor;
+    moves: MovesMap;
+    clock?: ClockMs | null;
+  }) => void;
   setMoves: (moves: MovesMap) => void;
   setClock: (clock: ClockMs | null) => void;
   setGameOver: (state: GameOverState | null) => void;
@@ -190,6 +197,31 @@ export const GameProvider: ParentComponent = (props) => {
     setStore("game", update);
   }
 
+  // Apply a server-accepted undo. The server sends the authoritative
+  // post-undo position; moveCount says how many entries to drop from
+  // the local history (the server does not resend the full history).
+  function applyExternalUndo(event: {
+    moveCount: number;
+    boardRep: BoardRep;
+    currentPlayer: PlayerColor;
+    moves: MovesMap;
+    clock?: ClockMs | null;
+  }): void {
+    const newLength = Math.max(
+      0,
+      store.game.moveHistory.length - event.moveCount,
+    );
+    const update: Partial<GameState> = {
+      moveHistory: store.game.moveHistory.slice(0, newLength),
+      historyCursor: 0,
+      currentPlayer: event.currentPlayer,
+      boardRep: event.boardRep,
+      moves: event.moves,
+    };
+    if ("clock" in event) update.clock = event.clock;
+    setStore("game", update);
+  }
+
   function setMovesAction(moves: MovesMap): void {
     setStore("game", "moves", moves);
   }
@@ -303,6 +335,7 @@ export const GameProvider: ParentComponent = (props) => {
     lastMove,
     applyMove,
     applyExternalMove,
+    applyExternalUndo,
     setMoves: setMovesAction,
     setClock: setClockAction,
     setGameOver: setGameOverAction,

--- a/frontend/src/gameOptions.test.ts
+++ b/frontend/src/gameOptions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getTimeControl, timeOptions } from "./gameOptions";
+
+describe("timeOptions", () => {
+  it("has exactly 3 timed options", () => {
+    const timed = timeOptions.filter((o) => o.timeControl !== null);
+    expect(timed).toHaveLength(3);
+  });
+
+  it("untimed option has null timeControl", () => {
+    expect(getTimeControl("none")).toBeNull();
+  });
+
+  it("timed options have correct seconds values", () => {
+    const expected = [
+      { label: "5 min", initialTime: 300, increment: 0 },
+      { label: "10 min", initialTime: 600, increment: 0 },
+      { label: "15 min", initialTime: 900, increment: 0 },
+    ];
+    for (const { label, initialTime, increment } of expected) {
+      const opt = timeOptions.find((o) => o.label === label);
+      expect(opt?.timeControl).toEqual({ initialTime, increment });
+    }
+  });
+
+  it("throws for unknown value", () => {
+    expect(() => getTimeControl("unknown")).toThrow();
+  });
+});

--- a/frontend/src/gameOptions.ts
+++ b/frontend/src/gameOptions.ts
@@ -6,9 +6,35 @@ export const sideOptions: SelectOption[] = [
   { value: "random", label: "Random" },
 ];
 
-export const timeOptions: SelectOption[] = [
-  { value: "none", label: "Untimed" },
-  { value: "5+0", label: "5 min" },
-  { value: "10+0", label: "10 min" },
-  { value: "15+0", label: "15 min" },
+export interface TimeControlValue {
+  initialTime: number;
+  increment: number;
+}
+
+export interface TimeOption extends SelectOption {
+  timeControl: TimeControlValue | null;
+}
+
+function formatTimeControl(tc: TimeControlValue): string {
+  const mins = Math.floor(tc.initialTime / 60);
+  if (tc.increment === 0) return `${mins} min`;
+  return `${mins}+${tc.increment}`;
+}
+
+function createTimeOption(tc: TimeControlValue): TimeOption {
+  const label = formatTimeControl(tc);
+  return { value: label, label, timeControl: tc };
+}
+
+export const timeOptions: TimeOption[] = [
+  { value: "none", label: "Untimed", timeControl: null },
+  createTimeOption({ initialTime: 300, increment: 0 }),
+  createTimeOption({ initialTime: 600, increment: 0 }),
+  createTimeOption({ initialTime: 900, increment: 0 }),
 ];
+
+export function getTimeControl(value: string): TimeControlValue | null {
+  const opt = timeOptions.find((o) => o.value === value);
+  if (!opt) throw new Error(`Unknown time control value: ${value}`);
+  return opt.timeControl;
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -2,11 +2,12 @@
 
 import { Route, Router } from "@solidjs/router";
 import { render } from "solid-js/web";
-import {
-  AiGameProvider,
-  HotseatApiProvider,
-  OnlineGameProvider,
-} from "./api/providers";
+
+const useMocks = import.meta.env.VITE_USE_MOCKS === "true";
+const { HotseatApiProvider, AiGameProvider, OnlineGameProvider } = useMocks
+  ? await import("./mocks/providers")
+  : await import("./api/providers");
+
 import AiGame from "./controllers/AiController";
 import HotseatGame from "./controllers/HotseatController";
 import OnlineGame from "./controllers/OnlineController";

--- a/frontend/src/mocks/mock-online-game.ts
+++ b/frontend/src/mocks/mock-online-game.ts
@@ -281,7 +281,8 @@ export function createMockOnlineGameService(): OnlineGameService {
   };
 
   // Expose for Playwright and manual browser console use.
-  window.__simulateTimeout = service.simulateTimeout;
+  window.__simulateTimeout = (delayMs?: number) =>
+    service.simulateTimeout?.(delayMs);
 
   return service;
 }

--- a/frontend/src/mocks/mock-online-game.ts
+++ b/frontend/src/mocks/mock-online-game.ts
@@ -1,6 +1,6 @@
 import { createSignal } from "solid-js";
 import type { OnlineGameService } from "../api/online-game-service";
-import type { OnlineGameEvent } from "../api/types";
+import type { ClockMs, OnlineGameEvent } from "../api/types";
 import {
   applyMoveToBoardRep,
   type BoardRep,
@@ -9,6 +9,7 @@ import {
   type PlayerColor,
   startBoard,
 } from "../board-logic";
+import type { TimeControlValue } from "../gameOptions";
 import {
   checkGameOver,
   generateLegalMoves,
@@ -32,12 +33,45 @@ export function createMockOnlineGameService(): OnlineGameService {
   let inviteToken: string | null = null;
   let active = false;
 
+  // Clock simulation. When timeControl is null the game is untimed and
+  // every event carries a null clock. Otherwise both banks start at the
+  // initial time and the side to move spends from turnStartedAtMs.
+  let timeControl: TimeControlValue | null = null;
+  let whiteMs = 0;
+  let blackMs = 0;
+  let turnStartedAtMs = 0;
+
   const [events, setEvents] = createSignal<OnlineGameEvent | undefined>();
   const [connected, setConnected] = createSignal(false);
   const [connecting] = createSignal(false);
 
   function emitIfActive(event: OnlineGameEvent) {
     if (active) setEvents(event);
+  }
+
+  function clockSnapshot(): ClockMs | null {
+    if (!timeControl) return null;
+    return { whiteMs, blackMs, turnStartedAtMs };
+  }
+
+  // Update the clock for a completed move by `mover`. The opening move
+  // is free and only starts the opponent's clock; later moves deduct the
+  // elapsed turn time and add the increment.
+  function advanceClock(mover: PlayerColor, firstMove: boolean) {
+    if (!timeControl) return;
+    const now = Date.now();
+    if (firstMove) {
+      turnStartedAtMs = now;
+      return;
+    }
+    const elapsed = now - turnStartedAtMs;
+    const incMs = timeControl.increment * 1000;
+    if (mover === "white") {
+      whiteMs = Math.max(0, whiteMs - elapsed) + incMs;
+    } else {
+      blackMs = Math.max(0, blackMs - elapsed) + incMs;
+    }
+    turnStartedAtMs = now;
   }
 
   function performUndo() {
@@ -56,7 +90,7 @@ export function createMockOnlineGameService(): OnlineGameService {
       boardRep: cloneBoardRep(board),
       currentPlayer,
       moves,
-      clock: null,
+      clock: clockSnapshot(),
     });
   }
 
@@ -69,7 +103,7 @@ export function createMockOnlineGameService(): OnlineGameService {
         type: "gameOver",
         winner: gameOver.winner,
         reason: gameOver.reason,
-        clock: null,
+        clock: clockSnapshot(),
       });
       return;
     }
@@ -77,9 +111,12 @@ export function createMockOnlineGameService(): OnlineGameService {
     const move = pickRandomMove(moves);
     if (!move) return;
 
+    const mover = currentPlayer;
+    const firstMove = moveHistory.length === 0;
     board = applyMoveToBoardRep(board, move);
     moveHistory.push(move);
     currentPlayer = currentPlayer === "black" ? "white" : "black";
+    advanceClock(mover, firstMove);
 
     const nextMoves = generateLegalMoves(board, currentPlayer);
     emitIfActive({
@@ -88,7 +125,7 @@ export function createMockOnlineGameService(): OnlineGameService {
       boardRep: cloneBoardRep(board),
       currentPlayer,
       moves: nextMoves,
-      clock: null,
+      clock: clockSnapshot(),
     });
 
     const nextGameOver = checkGameOver(board, currentPlayer, nextMoves);
@@ -98,7 +135,7 @@ export function createMockOnlineGameService(): OnlineGameService {
           type: "gameOver",
           winner: nextGameOver.winner,
           reason: nextGameOver.reason,
-          clock: null,
+          clock: clockSnapshot(),
         });
       }, 100);
     }
@@ -112,6 +149,7 @@ export function createMockOnlineGameService(): OnlineGameService {
   const service: OnlineGameService = {
     createGame(opts) {
       creatorColor = opts.creatorColor;
+      timeControl = opts.timeControl;
       playerToken = crypto.randomUUID();
       inviteToken = crypto.randomUUID();
       return Promise.resolve({
@@ -127,6 +165,11 @@ export function createMockOnlineGameService(): OnlineGameService {
       moveHistory = [];
       active = true;
       setConnected(true);
+      if (timeControl) {
+        whiteMs = timeControl.initialTime * 1000;
+        blackMs = timeControl.initialTime * 1000;
+        turnStartedAtMs = Date.now();
+      }
 
       const playerColor = resolvePlayerColor(token);
       const initialMoves = generateLegalMoves(board, currentPlayer);
@@ -139,7 +182,7 @@ export function createMockOnlineGameService(): OnlineGameService {
         moves: initialMoves,
         moveHistory: [],
         gameOver: null,
-        clock: null,
+        clock: clockSnapshot(),
       });
 
       setTimeout(() => emitIfActive({ type: "opponentJoined" }), 300);
@@ -158,9 +201,12 @@ export function createMockOnlineGameService(): OnlineGameService {
 
     sendMove(move) {
       if (!active) return;
+      const mover = currentPlayer;
+      const firstMove = moveHistory.length === 0;
       board = applyMoveToBoardRep(board, move);
       moveHistory.push(move);
       currentPlayer = currentPlayer === "black" ? "white" : "black";
+      advanceClock(mover, firstMove);
 
       const nextMoves = generateLegalMoves(board, currentPlayer);
       setEvents({
@@ -169,7 +215,7 @@ export function createMockOnlineGameService(): OnlineGameService {
         boardRep: cloneBoardRep(board),
         currentPlayer,
         moves: nextMoves,
-        clock: null,
+        clock: clockSnapshot(),
       });
 
       const gameOver = checkGameOver(board, currentPlayer, nextMoves);
@@ -179,7 +225,7 @@ export function createMockOnlineGameService(): OnlineGameService {
             type: "gameOver",
             winner: gameOver.winner,
             reason: gameOver.reason,
-            clock: null,
+            clock: clockSnapshot(),
           });
         }, 100);
         return;
@@ -196,7 +242,7 @@ export function createMockOnlineGameService(): OnlineGameService {
         type: "gameOver",
         winner,
         reason: "Resignation",
-        clock: null,
+        clock: clockSnapshot(),
       });
     },
 
@@ -208,7 +254,7 @@ export function createMockOnlineGameService(): OnlineGameService {
             type: "gameOver",
             winner: "draw",
             reason: "Draw agreed",
-            clock: null,
+            clock: clockSnapshot(),
           });
         } else {
           emitIfActive({ type: "drawDeclined" });
@@ -222,7 +268,7 @@ export function createMockOnlineGameService(): OnlineGameService {
         type: "gameOver",
         winner: "draw",
         reason: "Draw agreed",
-        clock: null,
+        clock: clockSnapshot(),
       });
     },
 
@@ -270,7 +316,7 @@ export function createMockOnlineGameService(): OnlineGameService {
           type: "gameOver",
           winner,
           reason: "timeout",
-          clock: null,
+          clock: clockSnapshot(),
         });
       }, delayMs);
     },

--- a/frontend/src/mocks/mock-online-game.ts
+++ b/frontend/src/mocks/mock-online-game.ts
@@ -49,6 +49,7 @@ export function createMockOnlineGameService(): OnlineGameService {
         type: "gameOver",
         winner: gameOver.winner,
         reason: gameOver.reason,
+        clock: null,
       });
       return;
     }
@@ -67,6 +68,7 @@ export function createMockOnlineGameService(): OnlineGameService {
       boardRep: cloneBoardRep(board),
       currentPlayer,
       moves: nextMoves,
+      clock: null,
     });
 
     const nextGameOver = checkGameOver(board, currentPlayer, nextMoves);
@@ -76,6 +78,7 @@ export function createMockOnlineGameService(): OnlineGameService {
           type: "gameOver",
           winner: nextGameOver.winner,
           reason: nextGameOver.reason,
+          clock: null,
         });
       }, 100);
     }
@@ -116,6 +119,7 @@ export function createMockOnlineGameService(): OnlineGameService {
         moves: initialMoves,
         moveHistory: [],
         gameOver: null,
+        clock: null,
       });
 
       setTimeout(() => emitIfActive({ type: "opponentJoined" }), 300);
@@ -145,6 +149,7 @@ export function createMockOnlineGameService(): OnlineGameService {
         boardRep: cloneBoardRep(board),
         currentPlayer,
         moves: nextMoves,
+        clock: null,
       });
 
       const gameOver = checkGameOver(board, currentPlayer, nextMoves);
@@ -154,6 +159,7 @@ export function createMockOnlineGameService(): OnlineGameService {
             type: "gameOver",
             winner: gameOver.winner,
             reason: gameOver.reason,
+            clock: null,
           });
         }, 100);
         return;
@@ -166,7 +172,12 @@ export function createMockOnlineGameService(): OnlineGameService {
       if (!active) return;
       // The resigning player loses
       const winner = creatorColor === "black" ? "white" : "black";
-      setEvents({ type: "gameOver", winner, reason: "Resignation" });
+      setEvents({
+        type: "gameOver",
+        winner,
+        reason: "Resignation",
+        clock: null,
+      });
     },
 
     offerDraw() {
@@ -177,6 +188,7 @@ export function createMockOnlineGameService(): OnlineGameService {
             type: "gameOver",
             winner: "draw",
             reason: "Draw agreed",
+            clock: null,
           });
         } else {
           emitIfActive({ type: "drawDeclined" });
@@ -186,7 +198,12 @@ export function createMockOnlineGameService(): OnlineGameService {
 
     acceptDraw() {
       if (!active) return;
-      setEvents({ type: "gameOver", winner: "draw", reason: "Draw agreed" });
+      setEvents({
+        type: "gameOver",
+        winner: "draw",
+        reason: "Draw agreed",
+        clock: null,
+      });
     },
 
     declineDraw() {
@@ -197,7 +214,7 @@ export function createMockOnlineGameService(): OnlineGameService {
       if (!active) return;
       setTimeout(() => {
         if (Math.random() < 0.5) {
-          emitIfActive({ type: "undoAccepted", moveCount: 1 });
+          emitIfActive({ type: "undoAccepted", moveCount: 1, clock: null });
         } else {
           emitIfActive({ type: "undoDeclined" });
         }
@@ -213,7 +230,7 @@ export function createMockOnlineGameService(): OnlineGameService {
         board = applyMoveToBoardRep(board, m);
         currentPlayer = currentPlayer === "black" ? "white" : "black";
       }
-      setEvents({ type: "undoAccepted", moveCount: 1 });
+      setEvents({ type: "undoAccepted", moveCount: 1, clock: null });
     },
 
     declineUndo() {

--- a/frontend/src/mocks/mock-online-game.ts
+++ b/frontend/src/mocks/mock-online-game.ts
@@ -89,7 +89,7 @@ export function createMockOnlineGameService(): OnlineGameService {
     return creatorColor === "black" ? "white" : "black";
   }
 
-  return {
+  const service: OnlineGameService = {
     createGame(opts) {
       creatorColor = opts.creatorColor;
       playerToken = crypto.randomUUID();
@@ -248,8 +248,27 @@ export function createMockOnlineGameService(): OnlineGameService {
       }, 500);
     },
 
+    simulateTimeout(delayMs = 2000) {
+      if (!active) return;
+      const loser = currentPlayer;
+      const winner = loser === "black" ? "white" : "black";
+      setTimeout(() => {
+        emitIfActive({
+          type: "gameOver",
+          winner,
+          reason: "timeout",
+          clock: null,
+        });
+      }, delayMs);
+    },
+
     events,
     connected,
     connecting,
   };
+
+  // Expose for Playwright and manual browser console use.
+  window.__simulateTimeout = service.simulateTimeout;
+
+  return service;
 }

--- a/frontend/src/mocks/mock-online-game.ts
+++ b/frontend/src/mocks/mock-online-game.ts
@@ -40,6 +40,26 @@ export function createMockOnlineGameService(): OnlineGameService {
     if (active) setEvents(event);
   }
 
+  function performUndo() {
+    if (moveHistory.length === 0) return;
+    moveHistory.pop();
+    board = cloneBoardRep(startBoard);
+    currentPlayer = "black";
+    for (const m of moveHistory) {
+      board = applyMoveToBoardRep(board, m);
+      currentPlayer = currentPlayer === "black" ? "white" : "black";
+    }
+    const moves = generateLegalMoves(board, currentPlayer);
+    emitIfActive({
+      type: "undoAccepted",
+      moveCount: 1,
+      boardRep: cloneBoardRep(board),
+      currentPlayer,
+      moves,
+      clock: null,
+    });
+  }
+
   function opponentTurn() {
     if (!active) return;
     const moves = generateLegalMoves(board, currentPlayer);
@@ -214,7 +234,7 @@ export function createMockOnlineGameService(): OnlineGameService {
       if (!active) return;
       setTimeout(() => {
         if (Math.random() < 0.5) {
-          emitIfActive({ type: "undoAccepted", moveCount: 1, clock: null });
+          performUndo();
         } else {
           emitIfActive({ type: "undoDeclined" });
         }
@@ -223,14 +243,7 @@ export function createMockOnlineGameService(): OnlineGameService {
 
     acceptUndo() {
       if (!active || moveHistory.length === 0) return;
-      moveHistory.pop();
-      board = cloneBoardRep(startBoard);
-      currentPlayer = "black";
-      for (const m of moveHistory) {
-        board = applyMoveToBoardRep(board, m);
-        currentPlayer = currentPlayer === "black" ? "white" : "black";
-      }
-      setEvents({ type: "undoAccepted", moveCount: 1, clock: null });
+      performUndo();
     },
 
     declineUndo() {

--- a/frontend/src/mocks/providers.ts
+++ b/frontend/src/mocks/providers.ts
@@ -15,3 +15,9 @@ export const MockAiGameProvider = aiGameContext.createProvider(
 export const MockOnlineGameProvider = onlineGameContext.createProvider(
   createMockOnlineGameService,
 );
+
+export {
+  MockAiGameProvider as AiGameProvider,
+  MockHotseatApiProvider as HotseatApiProvider,
+  MockOnlineGameProvider as OnlineGameProvider,
+};

--- a/frontend/src/test-globals.d.ts
+++ b/frontend/src/test-globals.d.ts
@@ -1,0 +1,4 @@
+/** Test hooks exposed by mock services for Playwright and console use. */
+interface Window {
+  __simulateTimeout?: (delayMs?: number) => void;
+}


### PR DESCRIPTION
## Summary

Adds Fischer-style time controls to online games — configurable initial time + per-move increment — end to end across the C-linked Haskell backend and the SolidJS frontend. Untimed games are unaffected.

Built in three shippable slices, then hardened:

- **Data plumbing** — `TimeControl` domain type, migration, storage, create-game API, and frontend selection.
- **Clock state + display** — server computes clock transitions on moves, persists them, and ships authoritative values over the WebSocket; the frontend renders live clocks.
- **Timeout enforcement** — per-game async timers fire `TimedOut`, with restart recovery and an hourly sweeper for abandoned games.

## Behaviour

- Time control is chosen at game creation (`Untimed`, `5 min`, `10 min`, `15 min`); untimed games behave exactly as before.
- The **opening move is free** — the clock starts once the first move is played. Both the deduction *and* the timeout enforcement honour this, so a player cannot flag before making their first move.
- The side to move counts down from the authoritative turn start (`turnStartedAtMs`), so the display stays accurate across reconnects and network delay rather than drifting.
- Running out of time loses the game; the outcome flows through the existing `gameOver` path. Clocks survive a server restart (timer recovery) and abandoned expired games are resolved by a sweeper.
- The clock is the authority on disconnect — a player still flags if they disconnect on their turn (standard online-game behaviour).

## Design notes

- **`GameClock` sum type on `State`**: `Untimed | Timed TimeControl ClockState`. Immutable configuration and mutable running state travel together, so "timed" is a single invariant (no representable `(Just tc, Nothing cs)`), and the configuration survives into the `Finished` phase.
- **Deadline-based timers**: timers sleep to an absolute deadline captured before forking, so the target can't drift with the spawned thread's start; a stale `TimeoutFired` for a player no longer to move is dropped silently rather than surfaced as a client error.
- **Time units**: seconds at the config/UI boundary (`5+0`), milliseconds on the wire and in the runtime DB columns. `NULL` columns mean untimed throughout.

## Testing

- **Backend** (201 tests): clock transition unit tests (including the free opening move), timeout enforcement + "no timeout before the first move", timer recovery, serialization/wire-format tests, and the online-session integration tests. The timeout timer tests were made deterministic (previously flaky under parallel load).
- **Frontend** (145 unit + 26 e2e): pure clock-countdown and undo-sync unit tests; the online mock now simulates a real clock, enabling e2e coverage of a timed game's clock ticking and an untimed game showing none.
- Full `ci-build-and-test.sh` (C build + C tests + Haskell build + Haskell tests + frontend lint/typecheck/unit + generated-type check + e2e) passes.

## Notes

The branch also carries some supporting tooling that landed alongside the feature (review skills, auto-format hooks, an OTel span-link addition, and an online-session event-loop refactor).
